### PR TITLE
Added Socket-Proxy option for Dozzle

### DIFF
--- a/servapps/Dozzle/cosmos-compose.json
+++ b/servapps/Dozzle/cosmos-compose.json
@@ -6,7 +6,31 @@
         "label": "Do you want to make this service admin only?",
         "initialValue": false,
         "type": "checkbox"
+      },
+      { 
+        "name": "useSocketProxy",
+        "label": "Do you want to use a socket proxy container for increased security?",
+        "initialValue": false,
+        "type": "checkbox"
       }
+      {if Context.useSocketProxy}
+        ,
+        { 
+          "name": "createSocketProxy",
+          "label": "Do you already have a socket-proxy container?",
+          "initialValue": false,
+          "type": "checkbox"
+        }
+        {if Context.createSocketProxy}
+          ,
+          {
+          "name": "socketProxy",
+          "name-container": "socket-proxy-name",
+          "label": "Where is your Socket Proxy container? (leave blank to create one)",
+          "type": "container"
+          }
+        {/if}
+      {/if}
     ]
   },
   "services": {
@@ -20,12 +44,16 @@
         "DOZZLE_LEVEL=info",
         "DOZZLE_TAILSIZE=300",
         "DOZZLE_FILTER=status=running"
+        {if Context.useSocketProxy}
+          , "DOCKER_HOST=tcp://socket-proxy:2375"
+        {/if}
       ],
       "labels": {
         "cosmos-force-network-secured": "true",
         "cosmos-auto-update": "true",
         "cosmos-icon": "https://azukaar.github.io/cosmos-servapps-official/servapps/Dozzle/icon.png"
       },
+      {if not Context.useSocketProxy}
       "volumes": [
         {
           "source": "/var/run/docker.sock",
@@ -33,6 +61,7 @@
           "type": "bind"
         }
       ],
+      {/if}
       "routes": [
         {
           "name": "{ServiceName}",
@@ -53,5 +82,62 @@
         }
       ]
     }
+    {if Context.useSocketProxy}
+      {if not Context.createSocketProxy}
+        ,
+        "Socket-Proxy": {
+          "image": "tecnativa/docker-socket-proxy",
+          "container_name": "Socket-Proxy",
+          "hostname": "Socket-Proxy",
+          "restart": "unless-stopped",
+          "security_opt": [
+            "no-new-privileges:true"
+          ],
+          "ports": [
+            "2375:2375"
+          ],
+          "labels": {
+            "cosmos-force-network-secured": "true",
+            "cosmos-network-name": "AUTO"
+          },
+          "volumes": [
+            {
+              "source": "/var/run/docker.sock",
+              "target": "/var/run/docker.sock",
+              "type": "bind"
+              }
+          ],
+          "environment": [
+            "LOG_LEVEL=info",
+            "EVENTS=1",
+            "PING=1",
+            "VERSION=1",
+            "AUTH=0",
+            "SECRETS=0",
+            "POST=0",
+            "BUILD=0",
+            "COMMIT=0",
+            "CONFIGS=0",
+            "CONTAINERS=1",
+            "DISTRIBUTION=0",
+            "EXEC=0",
+            "IMAGES=1", 
+            "INFO=1", 
+            "NETWORKS=1", 
+            "NODES=0",
+            "PLUGINS=0",
+            "SERVICES=1", 
+            "SESSION=0",
+            "SWARM=0",
+            "SYSTEM=0",
+            "TASKS=1", 
+            "VOLUMES=1" 
+          ],
+          "links": [
+            "{ServiceName}"
+          ]
+        }
+      {/if}
+    {/if}
   }
 }

--- a/servapps/Dozzle/cosmos-compose.json
+++ b/servapps/Dozzle/cosmos-compose.json
@@ -9,28 +9,10 @@
       },
       { 
         "name": "useSocketProxy",
-        "label": "Do you want to use a socket proxy container for increased security?",
-        "initialValue": false,
+        "label": "Do you want to use a socket-proxy for increased security? (i.e., create socket-proxy container insead of exposing docker.sock)",
+        "initialValue": true,
         "type": "checkbox"
       }
-      {if Context.useSocketProxy}
-        ,
-        { 
-          "name": "createSocketProxy",
-          "label": "Do you already have a socket-proxy container?",
-          "initialValue": false,
-          "type": "checkbox"
-        }
-        {if Context.createSocketProxy}
-          ,
-          {
-          "name": "socketProxy",
-          "name-container": "socket-proxy-name",
-          "label": "Where is your Socket Proxy container? (leave blank to create one)",
-          "type": "container"
-          }
-        {/if}
-      {/if}
     ]
   },
   "services": {
@@ -83,61 +65,59 @@
       ]
     }
     {if Context.useSocketProxy}
-      {if not Context.createSocketProxy}
-        ,
-        "Socket-Proxy": {
-          "image": "tecnativa/docker-socket-proxy",
-          "container_name": "Socket-Proxy",
-          "hostname": "Socket-Proxy",
-          "restart": "unless-stopped",
-          "security_opt": [
-            "no-new-privileges:true"
-          ],
-          "ports": [
-            "2375:2375"
-          ],
-          "labels": {
-            "cosmos-force-network-secured": "true",
-            "cosmos-network-name": "AUTO"
-          },
-          "volumes": [
-            {
-              "source": "/var/run/docker.sock",
-              "target": "/var/run/docker.sock",
-              "type": "bind"
-              }
-          ],
-          "environment": [
-            "LOG_LEVEL=info",
-            "EVENTS=1",
-            "PING=1",
-            "VERSION=1",
-            "AUTH=0",
-            "SECRETS=0",
-            "POST=0",
-            "BUILD=0",
-            "COMMIT=0",
-            "CONFIGS=0",
-            "CONTAINERS=1",
-            "DISTRIBUTION=0",
-            "EXEC=0",
-            "IMAGES=1", 
-            "INFO=1", 
-            "NETWORKS=1", 
-            "NODES=0",
-            "PLUGINS=0",
-            "SERVICES=1", 
-            "SESSION=0",
-            "SWARM=0",
-            "SYSTEM=0",
-            "TASKS=1", 
-            "VOLUMES=1" 
-          ],
-          "links": [
-            "{ServiceName}"
-          ]
-        }
-      {/if}
+      ,
+      "{ServiceName}-socket": {
+        "image": "tecnativa/docker-socket-proxy",
+        "container_name": "{ServiceName}-socket",
+        "hostname": "{ServiceName}-socket",
+        "restart": "unless-stopped",
+        "security_opt": [
+          "no-new-privileges:true"
+        ],
+        "ports": [
+          "2375:2375"
+        ],
+        "labels": {
+          "cosmos-force-network-secured": "true",
+          "cosmos-network-name": "AUTO"
+        },
+        "volumes": [
+          {
+            "source": "/var/run/docker.sock",
+            "target": "/var/run/docker.sock",
+            "type": "bind"
+            }
+        ],
+        "environment": [
+          "LOG_LEVEL=info",
+          "EVENTS=1",
+          "PING=1",
+          "VERSION=1",
+          "AUTH=0",
+          "SECRETS=0",
+          "POST=0",
+          "BUILD=0",
+          "COMMIT=0",
+          "CONFIGS=0",
+          "CONTAINERS=1",
+          "DISTRIBUTION=0",
+          "EXEC=0",
+          "IMAGES=0",
+          "INFO=0",
+          "NETWORKS=0", 
+          "NODES=0",
+          "PLUGINS=0",
+          "SERVICES=0", 
+          "SESSION=0",
+          "SWARM=0",
+          "SYSTEM=0",
+          "TASKS=0", 
+          "VOLUMES=0"
+        ],
+        "links": [
+          "{ServiceName}"
+        ]
+      }
     {/if}
   }
 }


### PR DESCRIPTION
Previously docker.sock included as a volume.
Now, default setting is to create a socket-proxy container (can be unchecked to use the docker.sock directly). 

The socket-proxy only grants access to CONTAINERS as that is all Dozzle requires.  All others are revoked ([with the exception of EVENTS, PING, and VERSION which are granted access by default](https://github.com/Tecnativa/docker-socket-proxy#access-granted-by-default))