### PR TITLE
Enhanced Filebrowser with NOAUTH option

### DIFF
--- a/servapps/Filebrowser/cosmos-compose.json
+++ b/servapps/Filebrowser/cosmos-compose.json
@@ -12,6 +12,12 @@
         "label": "Do you want to make this service admin only?",
         "initialValue": false,
         "type": "checkbox"
+      },
+      {
+        "name": "noAuth",
+        "label": "Do you to disable Filebrowser authentication?",
+        "initialValue": false,
+        "type": "checkbox"
       }
     ],
     "post-install": [
@@ -34,6 +40,9 @@
         "PUID=1000",
         "PGID=1000",
         "TZ=auto"
+        {if Context.noAuth}
+        , "NO_AUth=noauth"
+        {/if}
       ],
       "post_install": [
         "filebrowser config init",


### PR DESCRIPTION
Added option to Filebrowser compose allowing user to choose a NOAUTH option.  If chosen, an environment variable is added which disables the Login/Logout authentication used by Filebrowser.  This option is potentially useful for users who want to leverage Cosmos for authentication only.