### PR TITLE
Enhance UptimeKuma with Socket-Proxy option

### DIFF
--- a/servapps/UptimeKuma/cosmos-compose.json
+++ b/servapps/UptimeKuma/cosmos-compose.json
@@ -17,7 +17,7 @@
         , 
         {
           "type": "warning",
-          "label": "Remember to edit the Docker Host inside Uptime-Kuma settings to attach the {ServiceName}-Socket-Proxy container. Use tcp://{ServiceName}-Socket-Proxy:2375"
+          "label": "Remember to edit the Docker Host inside Uptime-Kuma settings to attach the {ServiceName}-socket container. Use tcp://{ServiceName}-socket:2375"
         }
       {/if}
     ]
@@ -25,7 +25,7 @@
       , "post-install": [
         {
           "type": "warning",
-          "label": "Remember to edit the Docker Host inside Uptime-Kuma settings to attach the {ServiceName}-Socket-Proxy container. Use tcp://{ServiceName}-Socket-Proxy:2375"
+          "label": "Remember to edit the Docker Host inside Uptime-Kuma settings to attach the {ServiceName}-socket container. Use tcp://{ServiceName}-socket:2375"
         }
       ]
     {/if}
@@ -73,10 +73,10 @@
     }
     {if Context.useSocketProxy}
       ,
-      "{ServiceName}-Socket-Proxy": {
+      "{ServiceName}-socket": {
         "image": "tecnativa/docker-socket-proxy",
-        "container_name": "{ServiceName}-Socket-Proxy",
-        "hostname": "{ServiceName}-Socket-Proxy",
+        "container_name": "{ServiceName}-socket",
+        "hostname": "{ServiceName}-socket",
         "restart": "unless-stopped",
         "security_opt": [
           "no-new-privileges:true"
@@ -110,17 +110,17 @@
           "CONTAINERS=1",
           "DISTRIBUTION=0",
           "EXEC=0",
-          "IMAGES=1", 
-          "INFO=1", 
-          "NETWORKS=1", 
+          "IMAGES=0", 
+          "INFO=0", 
+          "NETWORKS=0", 
           "NODES=0",
           "PLUGINS=0",
-          "SERVICES=1", 
+          "SERVICES=0", 
           "SESSION=0",
           "SWARM=0",
           "SYSTEM=0",
-          "TASKS=1", 
-          "VOLUMES=1" 
+          "TASKS=0", 
+          "VOLUMES=0"
         ],
         "links": [
           "{ServiceName}"

--- a/servapps/UptimeKuma/cosmos-compose.json
+++ b/servapps/UptimeKuma/cosmos-compose.json
@@ -10,10 +10,25 @@
       { 
         "name": "useSocketProxy",
         "label": "Do you want to use a Docker Host? (aka Socket Proxy container)",
-        "initialValue": false,
+        "initialValue": true,
         "type": "checkbox"
       }
+      {if Context.useSocketProxy}
+        , 
+        {
+          "type": "warning",
+          "label": "Remember to edit the Docker Host inside Uptime-Kuma settings to attach the {ServiceName}-Socket-Proxy container. Use tcp://{ServiceName}-Socket-Proxy:2375"
+        }
+      {/if}
     ]
+    {if Context.useSocketProxy}
+      , "post-install": [
+        {
+          "type": "warning",
+          "label": "Remember to edit the Docker Host inside Uptime-Kuma settings to attach the {ServiceName}-Socket-Proxy container. Use tcp://{ServiceName}-Socket-Proxy:2375"
+        }
+      ]
+    {/if}
   },
   "minVersion": "0.8.0",
   "services": {
@@ -55,11 +70,6 @@
           {/if}
         }
       ]
-      {if Context.useSocketProxy}
-      , "links": [
-        "{ServiceName}-Socket-Proxy"
-      ]
-      {/if}
     }
     {if Context.useSocketProxy}
       ,
@@ -76,7 +86,8 @@
         ],
         "labels": {
           "cosmos-force-network-secured": "true",
-          "cosmos-network-name": "AUTO"
+          "cosmos-auto-update": "true",
+          "cosmos-icon": "https://azukaar.github.io/cosmos-servapps-official/servapps/UptimeKuma/icon.png"
         },
         "volumes": [
           {

--- a/servapps/UptimeKuma/cosmos-compose.json
+++ b/servapps/UptimeKuma/cosmos-compose.json
@@ -6,7 +6,31 @@
         "label": "Do you want to make this service admin only?",
         "initialValue": false,
         "type": "checkbox"
+      },
+      { 
+        "name": "useSocketProxy",
+        "label": "Do you want to use a Docker Host?",
+        "initialValue": false,
+        "type": "checkbox"
       }
+      {if Context.useSocketProxy}
+        ,
+        { 
+          "name": "createSocketProxy",
+          "label": "Do you already have a socket-proxy container?",
+          "initialValue": false,
+          "type": "checkbox"
+        }
+        {if Context.createSocketProxy}
+          ,
+          {
+          "name": "socketProxy",
+          "name-container": "socket-proxy-name",
+          "label": "Where is your Socket Proxy container? (leave blank to create one)",
+          "type": "container"
+          }
+        {/if}
+      {/if}
     ]
   },
   "minVersion": "0.8.0",
@@ -49,6 +73,68 @@
           {/if}
         }
       ]
+      {if Context.socketProxy}
+      , "links": [
+        "{Context.socket-proxy-name}"
+      ]
+      {/if}
     }
+    {if Context.useSocketProxy}
+      {if not Context.createSocketProxy}
+        ,
+        "Socket-Proxy": {
+          "image": "tecnativa/docker-socket-proxy",
+          "container_name": "Socket-Proxy",
+          "hostname": "Socket-Proxy",
+          "restart": "unless-stopped",
+          "security_opt": [
+            "no-new-privileges:true"
+          ],
+          "ports": [
+            "2375:2375"
+          ],
+          "labels": {
+            "cosmos-force-network-secured": "true",
+            "cosmos-network-name": "AUTO"
+          },
+          "volumes": [
+            {
+              "source": "/var/run/docker.sock",
+              "target": "/var/run/docker.sock",
+              "type": "bind"
+              }
+          ],
+          "environment": [
+            "LOG_LEVEL=info",
+            "EVENTS=1",
+            "PING=1",
+            "VERSION=1",
+            "AUTH=0",
+            "SECRETS=0",
+            "POST=0",
+            "BUILD=0",
+            "COMMIT=0",
+            "CONFIGS=0",
+            "CONTAINERS=1",
+            "DISTRIBUTION=0",
+            "EXEC=0",
+            "IMAGES=1", 
+            "INFO=1", 
+            "NETWORKS=1", 
+            "NODES=0",
+            "PLUGINS=0",
+            "SERVICES=1", 
+            "SESSION=0",
+            "SWARM=0",
+            "SYSTEM=0",
+            "TASKS=1", 
+            "VOLUMES=1" 
+          ],
+          "links": [
+            "{ServiceName}"
+          ]
+        }
+      {/if}
+    {/if}
   }
 }

--- a/servapps/UptimeKuma/cosmos-compose.json
+++ b/servapps/UptimeKuma/cosmos-compose.json
@@ -9,7 +9,7 @@
       },
       { 
         "name": "useSocketProxy",
-        "label": "Do you want to use a Docker Host? (aka Socket Proxy container)",
+        "label": "Do you want to use a socket-proxy for increased security? (i.e., create socket-proxy container insead of exposing docker.sock)",
         "initialValue": true,
         "type": "checkbox"
       }


### PR DESCRIPTION
UptimeKuma settings has a Docker Hosts section. This enhancement lets the user connect to tcp://socket-proxy:2375 thus allowing the UptimeKuma monitor to watch the container directly in docker.

This commit/enhancement gives user an option to link to socket-proxy container.  The compose will ask if a socket-proxy should be used.   If yes, will then ask if one already exists.  
- If yes, link to the existing socket-proxy.  
- If no, create and link to it.