### PR TITLE
Tandoor: Force PostgreSQL to prevent SQLite

### DIFF
--- a/servapps/Tandoor/cosmos-compose.json
+++ b/servapps/Tandoor/cosmos-compose.json
@@ -10,6 +10,7 @@
       "environment": [
         "TZ=auto",
         "ALLOWED_HOSTS={Hostnames.{StaticServiceName}.{StaticServiceName}.host}",
+        "DB_ENGINE=django.db.backends.postgresql",
         "POSTGRES_DB=tandoor",
         "POSTGRES_USER=tandoor",
         "POSTGRES_PASSWORD={Passwords.0}",


### PR DESCRIPTION
When I deployed Tandoor I noticed it kept on using SQLite and on restart all data was gone since there was no persistence for the recipes container.

Setting DB_ENGINE forces it to use PostgreSQL