### PR TITLE
Fix trailing commas in Firefly III

### DIFF
--- a/servapps/Firefly-III/cosmos-compose.json
+++ b/servapps/Firefly-III/cosmos-compose.json
@@ -73,8 +73,8 @@
         "MARIADB_ROOT_PASSWORD={Passwords.2}"
       ],
       "labels": {
-        "cosmos-persistent-env": "MARIADB_DATABASE, MARIADB_USER, MARIADB_PASSWORD, MARIADB_ROOT_PASSWORD",
-      },
+        "cosmos-persistent-env": "MARIADB_DATABASE, MARIADB_USER, MARIADB_PASSWORD, MARIADB_ROOT_PASSWORD"
+      }
     }
   },
 


### PR DESCRIPTION
This fixes the JSON parsing errors for the Firefly III config.