### PR TITLE
joplin not support ARM

### DIFF
--- a/servapps/Joplin/description.json
+++ b/servapps/Joplin/description.json
@@ -5,5 +5,5 @@
   "tags": ["productivity", "note-taking", "to-do", "markdown", "encryption", "syncing", "windows", "linux", "macos", "ios", "android", "self-hosted", "joplin"],
   "repository": "https://github.com/laurent22/joplin",
   "image": "https://hub.docker.com/r/joplin/server",
-  "supported_architectures": ["amd64", "arm64"]
+  "supported_architectures": ["amd64"]
   }


### PR DESCRIPTION
Joplin image docker default not support ARM.


![image](https://github.com/azukaar/cosmos-servapps-official/assets/41409442/bd9321ad-4024-4f48-a794-41e390f155ee)
