### PR TITLE
Add support for Purpur Minecraft

### DIFF
--- a/servapps/Minecraft-Server/cosmos-compose.json
+++ b/servapps/Minecraft-Server/cosmos-compose.json
@@ -48,6 +48,7 @@
           ["SPIGOT", "Spigot"],
           ["FORGE", "Forge"],
           ["PAPER", "Paper"],
+          ["PURPUR", "Purpur"],
           ["FABRIC", "Fabric"]
         ]
       },


### PR DESCRIPTION
A Purpur server, which is a drop-in replacement for Paper servers designed for configurability and new, fun, exciting gameplay features.