### PR TITLE
fix: Incorrect filebrowser volume target.

### DIFF
--- a/servapps/Filebrowser/cosmos-compose.json
+++ b/servapps/Filebrowser/cosmos-compose.json
@@ -57,13 +57,13 @@
       },
       "volumes": [
         {
-          "source": "/usr/Filebrowser/{ServiceName}-database.db",
-          "target": "/database.db",
+          "source": "/usr/Filebrowser/filebrowser.db",
+          "target": "/database/filebrowser.db",
           "type": "bind"
         },
         {
-          "source": "/usr/Filebrowser/.{ServiceName}-filebrowser.json",
-          "target": "/.filebrowser.json",
+          "source": "/usr/Filebrowser/settings.json",
+          "target": "/config/settings.json",
           "type": "bind"
         },
         {


### PR DESCRIPTION
The files were being mounted incorrectly, remembering that an instruction is needed to create the files before installation as docker creates them as a directory. 

> If you don't already have a database file, make sure to create a new empty file under the path you specified. Otherwise, Docker will create an empty folder instead of an empty file, resulting in an error when mounting the database into the container.

See: https://filebrowser.org/installation#docker