### PR TITLE
Update Sonarqube email field type to "email" and change target port

### DIFF
--- a/servapps/Sonarqube/cosmos-compose.json
+++ b/servapps/Sonarqube/cosmos-compose.json
@@ -17,7 +17,7 @@
         "name": "SONARQUBE_EMAIL",
         "label": "What Sonarqube email does it use?",
         "initialValue": "email@Sonarqube.com",
-        "type": "password"
+        "type": "email"
       }
     ]
   },
@@ -60,7 +60,7 @@
           "name": "{ServiceName}",
           "description": "Expose {ServiceName} to the web",
           "useHost": true,
-          "target": "http://{ServiceName}:8069",
+          "target": "http://{ServiceName}:9000",
           "mode": "SERVAPP",
           "Timeout": 14400000,
           "ThrottlePerMinute": 12000,


### PR DESCRIPTION
For some reason the email field was set to 'password'. I have updated it to say 'email'. 
Additionally, I have modified the target web port to be 9000 which is the HTTP port for Sonarqube (current configs do not work). 