### PR TITLE
Fix space on vaultwarden cosmos json

### DIFF
--- a/servapps/Vaultwarden/cosmos-compose.json
+++ b/servapps/Vaultwarden/cosmos-compose.json
@@ -32,7 +32,7 @@
         "type": "select",
         "options": [
           ["starttls", "starttls"],
-          ["force_tls ", "force_tls"],
+          ["force_tls", "force_tls"],
           ["off", "off"]
         ]
       },


### PR DESCRIPTION
Hello,

I propose a fix (one space too many) in the `json` of vaultwarden which blocks the launching of the container when `force_tls` is chosen in `SMTP_SECURITY`.

Thanks for the great work by CosmosCloud