### PR TITLE
fix: File not found due to invalid URL for Monica icon

### DIFF
--- a/servapps/Monica/cosmos-compose.json
+++ b/servapps/Monica/cosmos-compose.json
@@ -31,7 +31,7 @@
             "cosmos-persistent-env": "DB_PASSWORD, DB_HOST, DB_PORT, DB_USERNAME",
             "cosmos-force-network-secured": "true",
             "cosmos-auto-update": "true",
-            "cosmos-icon": "https://azukaar.github.io/cosmos-servapps-official/Monica/icon.png",
+            "cosmos-icon": "https://azukaar.github.io/cosmos-servapps-official/servapps/Monica/icon.png",
             "cosmos-stack": "{ServiceName}",
             "cosmos-stack-main": "{ServiceName}"
           },


### PR DESCRIPTION
The url failed to load the image due to missing "`https://...`**/serveapps/**`.../icon.png`" directory in URL path.

Old:
`https://azukaar.github.io/cosmos-servapps-official/Monica/icon.png`

New:
`https://azukaar.github.io/cosmos-servapps-official/servapps/Monica/icon.png`