### PR TITLE
remove command start.sh from immich and microservices services

### DIFF
--- a/servapps/Immich/cosmos-compose.json
+++ b/servapps/Immich/cosmos-compose.json
@@ -29,7 +29,6 @@
       "container_name": "{ServiceName}",
       "hostname": "{ServiceName}",
       "image": "ghcr.io/immich-app/immich-server:release",
-      "command": "start.sh immich",
       "networks": {
         "{ServiceName}": {}
       },
@@ -91,7 +90,6 @@
       "container_name": "microservices",
       "hostname": "microservices",
       "image": "ghcr.io/immich-app/immich-server:release",
-      "command": "start.sh microservices",
       "networks": {
         "{ServiceName}": {}
       },


### PR DESCRIPTION

Immich won't do any jobs if those are left there after the update. It had some breaking changes of microservices container not needed anymore and such. (https://github.com/immich-app/immich/issues/10315)  . I think the microservices should be removed as a whole (idk how to word it). So yea
https://github.com/immich-app/immich/releases/tag/v1.106.4