### PR TITLE
Add new compose security options for Manyfold

### DIFF
--- a/servapps/Manyfold/cosmos-compose.json
+++ b/servapps/Manyfold/cosmos-compose.json
@@ -1,4 +1,4 @@
-{ 
+{
   "cosmos-installer": {
     "form": [
       {
@@ -34,7 +34,17 @@
         "DB_NAME=manyfold",
         "DB_PASS={Passwords.0}",
         "DB_PORT=5432"
-        
+      ],
+      "security_opt": [
+        "no-new-privileges:true"
+      ],
+      "cap_drop": [
+        "ALL"
+      ],
+      "cap_add": [
+        "CHOWN",
+        "SETGID",
+        "SETUID"
       ],
       "labels": {
         "cosmos-persistent-env": "SECRET_KEY_BASE, DB_PASS, DB_USER, DB_NAME",
@@ -76,7 +86,7 @@
         }
       ]
     },
-    
+
     "{ServiceName}-redis": {
       "restart": "always",
       "image": "redis:7-alpine",
@@ -101,7 +111,7 @@
       }
     },
 
-    
+
     "{ServiceName}-postgres": {
       "image": "postgres:15-alpine",
       "container_name": "{ServiceName}-postgres",
@@ -133,7 +143,7 @@
       ]
     }
   },
-  
+
   "networks": {
     "{ServiceName}-data": {
     }


### PR DESCRIPTION
Manyfold has just added a bunch of new security options, including container runtime recommendations. https://manyfold.app/sysadmin/security has all the details, but the main things are it now respects `PUID` and `PGID` which I see are already there, and has some suggested container options, which I've added in this PR.