### PR TITLE
add DAC_OVERRIDE permission for Manyfold

### DIFF
--- a/servapps/Manyfold/cosmos-compose.json
+++ b/servapps/Manyfold/cosmos-compose.json
@@ -44,6 +44,7 @@
       ],
       "cap_add": [
         "CHOWN",
+        "DAC_OVERRIDE",
         "SETGID",
         "SETUID"
       ],


### PR DESCRIPTION
Low priority, but required if anyone turns on the read-only filesystem docker option.