### PR TITLE
Update Dozzle compose

### DIFF
--- a/servapps/Dozzle/cosmos-compose.json
+++ b/servapps/Dozzle/cosmos-compose.json
@@ -24,10 +24,9 @@
       "GID": 1000,
       "environment": [
         "DOZZLE_LEVEL=info",
-        "DOZZLE_TAILSIZE=300",
         "DOZZLE_FILTER=status=running"
         {if Context.useSocketProxy}
-          , "DOCKER_HOST=tcp://{ServiceName}-socket:2375"
+          , "DOZZLE_REMOTE_HOST=tcp://{ServiceName}-socket:2375"
         {/if}
       ],
       "labels": {


### PR DESCRIPTION
Dozzle recipe was broken, due to Dozzle breaking changes

- remove deprecated ENV: DOZZLE_TAILSIZE
- fix ENV: REMOTE_HOST