### PR TITLE
Manyfold DATABASE_URL fix

### DIFF
--- a/servapps/Manyfold/cosmos-compose.json
+++ b/servapps/Manyfold/cosmos-compose.json
@@ -34,7 +34,7 @@
         "DB_NAME=manyfold",
         "DB_PASS={Passwords.0}",
         "DB_PORT=5432",
-	"DATABASE_URL=postgresql://{DB_USER}:{DB_PASS}@{DB_HOST}/{DB_NAME}?pool=5"
+	"DATABASE_URL=postgresql://manyfold:{Passwords.0}@{ServiceName}-postgres/manyfold?pool=5"
       ],
       "security_opt": [
         "no-new-privileges:true"

--- a/servapps/Manyfold/cosmos-compose.json
+++ b/servapps/Manyfold/cosmos-compose.json
@@ -29,11 +29,6 @@
         "REDIS_URL=redis://{ServiceName}-redis:6379",
         "REDIS_PORT=6379",
         "SECRET_KEY_BASE={Passwords.3}",
-        "DB_HOST={ServiceName}-postgres",
-        "DB_USER=manyfold",
-        "DB_NAME=manyfold",
-        "DB_PASS={Passwords.0}",
-        "DB_PORT=5432",
 	"DATABASE_URL=postgresql://manyfold:{Passwords.0}@{ServiceName}-postgres/manyfold?pool=5"
       ],
       "security_opt": [


### PR DESCRIPTION
These placeholders didn't seem to work and it ended up just showing ´postgresql://:@/?pool=5´.