### PR TITLE
Update Mealie cosmos-compose.json

### DIFF
--- a/servapps/Mealie/cosmos-compose.json
+++ b/servapps/Mealie/cosmos-compose.json
@@ -42,7 +42,7 @@
   "minVersion": "0.8.4",
   "services": {
     "{ServiceName}": {
-      "image": "ghcr.io/mealie-recipes/mealie:v1.0.0-RC2",
+      "image": "ghcr.io/mealie-recipes/mealie:latest",
       "container_name": "{ServiceName}",
       "restart": "unless-stopped",
       "environment": [


### PR DESCRIPTION
Current Servapp is pulling v1.0.0-RC2 which is over a year old and missing out on updates. I can't find any documentation what RC2 stands for, or if it's necessary for the Cosmos configuration, but the latest version v2.8.0 seems to be working properly on my machine.