### PR TITLE
Update CodeServer compose

### DIFF
--- a/servapps/CodeServer/cosmos-compose.json
+++ b/servapps/CodeServer/cosmos-compose.json
@@ -28,7 +28,9 @@
         "PGID=1000",
         "TZ=auto",
         "PROXY_DOMAIN={Hostnames.{StaticServiceName}.{StaticServiceName}.host}",
-        "DEFAULT_WORKSPACE=/workspace"
+        "DEFAULT_WORKSPACE=/workspace",
+        "SUDO_PASSWORD={password}",
+        "VSCODE_PROXY_URI=./proxy/{{port}}"
       ],
       "labels": {
         "cosmos-force-network-secured": "true",


### PR DESCRIPTION
Add Docker Environment Variables   
SUDO_PASSWORD - needed for sudo terminal access for things like installing python/pip for workspace VSCODE_PROXY_URI=./proxy/{{port}}  - changes port forwarding schema from sub-subdomain, which doesn't appear to work with the Cosmos reverse proxy/and or Let's Encrypt Security certificates, to a path schema. Useful for running a Django server inside venv