### PR TITLE
Use latest tags for auto-update and fix CashPilot repo URL

### DIFF
--- a/servapps/CashPilot/cosmos-compose.json
+++ b/servapps/CashPilot/cosmos-compose.json
@@ -2,7 +2,7 @@
   "minVersion": "0.13.0",
   "services": {
     "{ServiceName}": {
-      "image": "drumsergio/cashpilot:0.2.53",
+      "image": "drumsergio/cashpilot:latest",
       "container_name": "{ServiceName}",
       "restart": "unless-stopped",
       "environment": [
@@ -39,7 +39,7 @@
       ]
     },
     "{ServiceName}-worker": {
-      "image": "drumsergio/cashpilot-worker:0.2.53",
+      "image": "drumsergio/cashpilot-worker:latest",
       "container_name": "{ServiceName}-worker",
       "restart": "unless-stopped",
       "environment": [

--- a/servapps/CashPilot/description.json
+++ b/servapps/CashPilot/description.json
@@ -3,7 +3,7 @@
   "longDescription": "<p>CashPilot is a self-hosted dashboard for monitoring and managing bandwidth-sharing applications like EarnApp, Honeygain, IPRoyal, Peer2Profit, and more.</p><p>It provides a unified interface to track earnings, container status, and performance across all your bandwidth-sharing services. CashPilot supports 10+ applications and aggregates earnings data in a single view.</p><p>The architecture consists of a web UI container and a worker container that communicates with the Docker daemon to monitor your bandwidth-sharing containers. No database required — just deploy and start tracking.</p>",
   "description": "Self-hosted dashboard for monitoring and managing bandwidth-sharing applications. Track earnings, container status, and performance across EarnApp, Honeygain, IPRoyal, Peer2Profit, and 6+ more services in a single interface.",
   "tags": ["monitoring", "dashboard", "bandwidth", "passive income", "docker", "self-hosted"],
-  "repository": "https://github.com/GeiserX/m4b-dashboard",
+  "repository": "https://github.com/GeiserX/CashPilot",
   "image": "https://hub.docker.com/r/drumsergio/cashpilot",
   "supported_architectures": ["amd64", "arm64"]
 }

--- a/servapps/GenieACS/cosmos-compose.json
+++ b/servapps/GenieACS/cosmos-compose.json
@@ -2,7 +2,7 @@
   "minVersion": "0.13.0",
   "services": {
     "{ServiceName}": {
-      "image": "drumsergio/genieacs:1.2.16.0",
+      "image": "drumsergio/genieacs:latest",
       "container_name": "{ServiceName}",
       "restart": "unless-stopped",
       "environment": [

--- a/servapps/LynxPrompt/cosmos-compose.json
+++ b/servapps/LynxPrompt/cosmos-compose.json
@@ -12,7 +12,7 @@
   "minVersion": "0.13.0",
   "services": {
     "{ServiceName}": {
-      "image": "drumsergio/lynxprompt:2.0.75",
+      "image": "drumsergio/lynxprompt:latest",
       "container_name": "{ServiceName}",
       "restart": "unless-stopped",
       "environment": [

--- a/servapps/Pumperly/cosmos-compose.json
+++ b/servapps/Pumperly/cosmos-compose.json
@@ -12,7 +12,7 @@
   "minVersion": "0.13.0",
   "services": {
     "{ServiceName}": {
-      "image": "drumsergio/pumperly:1.2.0",
+      "image": "drumsergio/pumperly:latest",
       "container_name": "{ServiceName}",
       "restart": "unless-stopped",
       "environment": [


### PR DESCRIPTION
## Summary

- Switch all 4 app images (CashPilot, Pumperly, LynxPrompt, GenieACS) from pinned version tags to `:latest` so that `cosmos-auto-update: "true"` works without needing version-bump PRs on each release
- Fix CashPilot `description.json` repository link from the old `m4b-dashboard` name to the current `CashPilot` repo

## Changes

| App | Image | Old tag | New tag |
|-----|-------|---------|---------|
| CashPilot | drumsergio/cashpilot | 0.2.53 | latest |
| CashPilot Worker | drumsergio/cashpilot-worker | 0.2.53 | latest |
| Pumperly | drumsergio/pumperly | 1.2.0 | latest |
| LynxPrompt | drumsergio/lynxprompt | 2.0.75 | latest |
| GenieACS | drumsergio/genieacs | 1.2.16.0 | latest |

Follow-up to #208.