### PR TITLE
ci: bump deploy-to-pages actions to current latest

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -23,21 +23,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '18'
+          node-version: '24'
 
       - name: Build static files (if needed)
-        run: node index.js 
+        run: node index.js
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
-          path: '.' 
+          path: '.'
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary

The \`Deploy static content to Pages\` workflow pins versions that are about to break:

| Action | Current | Latest |
| --- | --- | --- |
| \`actions/checkout\` | v4 | **v6** |
| \`actions/setup-node\` | v4 | **v6** |
| \`actions/upload-pages-artifact\` | v3 | **v5** |
| \`actions/deploy-pages\` | v4 | **v5** |
| Node runtime | \`18\` (EOL April 2025) | \`24\` (current Active LTS) |

The deploy run for merge of #210 (HermitStash) already emitted GitHub's deprecation warning:

> Node.js 20 actions are deprecated. […] Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

Run: https://github.com/azukaar/Cosmos-ServApps-Official/actions/runs/24629322329

Bumping to current-latest puts the workflow on the new runtime voluntarily instead of breaking mid-2026.

## Notes

- No changes to \`index.js\` or any app code — workflow file only.
- After merge, the next push triggers a rebuild of \`servapps.json\` on the new toolchain (good time to also land #211 which adds the missing HermitStash screenshots that failed the current build).

## Test plan

- [ ] Workflow runs on next push to \`master\`
- [ ] No deprecation warnings in the run log
- [ ] \`servapps.json\` deploys successfully to GitHub Pages