### PR TITLE
Feat/servapp redmine update

### DIFF
--- a/servapps/Discourse/cosmos-compose.json
+++ b/servapps/Discourse/cosmos-compose.json
@@ -4,13 +4,13 @@
       {
         "name": "DISCOURSE_USERNAME",
         "label": "What is your discourse user login?",
-        "initialValue": "Tinyactive",
+        "initialValue": "",
         "type": "text"
       },
       {
         "name": "DISCOURSE_PASSWORD",
         "label": "What discourse password does it use?",
-        "initialValue": "fd4y3Sb4VnUbegrD",
+        "initialValue": "",
         "type": "password"
       }
     ]
@@ -18,7 +18,7 @@
   "minVersion": "0.9.0",
   "services": {
     "{ServiceName}": {
-      "image": "bitnami/discourse:latest",
+      "image": "discourse/discourse:latest",
       "container_name": "{ServiceName}",
       "hostname": "{ServiceName}",
       "restart": "unless-stopped",
@@ -70,7 +70,7 @@
       ]
     },
     "{ServiceName}-sidekiq": {
-      "image": "bitnami/discourse:latest",
+      "image": "discourse/discourse:latest",
       "container_name": "{ServiceName}-sidekiq",
       "hostname": "{ServiceName}-sidekiq",
       "restart": "unless-stopped",
@@ -139,7 +139,7 @@
       ]
     },
     "{ServiceName}-redis": {
-      "image": "bitnami/redis:7.0",
+      "image": "redis:7-alpine",
       "container_name": "{ServiceName}-redis",
       "hostname": "{ServiceName}-redis",
       "restart": "unless-stopped",

--- a/servapps/redmine/cosmos-compose.json
+++ b/servapps/redmine/cosmos-compose.json
@@ -4,31 +4,31 @@
       {
         "name": "REDMINE_USERNAME",
         "label": "What Redmine username do you want to use?",
-        "initialValue": "user",
+        "initialValue": "",
         "type": "text"
       },
       {
         "name": "REDMINE_PASSWORD",
         "label": "What Redmine password does it use?",
-        "initialValue": "bitnami1",
+        "initialValue": "",
         "type": "password"
       },
       {
         "name": "REDMINE_EMAIL",
         "label": "What is your Redmine email login?",
-        "initialValue": "user@example.com",
+        "initialValue": "",
         "type": "text"
       },
       {
         "name": "REDMINE_FIRST_NAME",
         "label": "What is your Redmine first name?",
-        "initialValue": "UserName",
+        "initialValue": "",
         "type": "text"
       },
       {
         "name": "REDMINE_LAST_NAME",
         "label": "What is your Redmine LastName?",
-        "initialValue": "LastName",
+        "initialValue": "",
         "type": "text"
       }
     ]
@@ -36,7 +36,7 @@
     "minVersion": "0.8.0",
     "services": {
       "{ServiceName}": {
-        "image": "docker.io/bitnami/redmine:5",
+        "image": "redmine:5.1.2-alpine",
         "container_name": "{ServiceName}",
         "hostname": "{ServiceName}",
         "volumes": [
@@ -85,7 +85,7 @@
 
       },
       "{ServiceName}-db": {
-        "image": "docker.io/bitnami/mariadb:11.1",
+        "image": "mariadb:11.1",
         "container_name": "{ServiceName}-db",
         "hostname": "{ServiceName}-db",
         "restart": "unless-stopped",


### PR DESCRIPTION
This pull request updates the configuration for the Discourse and Redmine service apps to improve security and modernize the images used. The most important changes are the removal of default credentials from environment variable templates and the replacement of Bitnami images with official or more lightweight alternatives.

**Security improvements:**

* Removed default values for user credentials (usernames, passwords, emails, and names) in the environment variable templates for both Discourse and Redmine, requiring users to provide their own secure values. [[1]](diffhunk://#diff-5941aa5950bee58498d55033025d6778f14f4555e839c11a97fe7eb9618250beL7-R21) [[2]](diffhunk://#diff-25ca0fa31b64619bb9cb51736ae75754c43132add8246983e63c12faf0ea022bL7-R39)

**Image updates:**

* Updated Discourse and Sidekiq service images from `bitnami/discourse:latest` to the official `discourse/discourse:latest` image. [[1]](diffhunk://#diff-5941aa5950bee58498d55033025d6778f14f4555e839c11a97fe7eb9618250beL7-R21) [[2]](diffhunk://#diff-5941aa5950bee58498d55033025d6778f14f4555e839c11a97fe7eb9618250beL73-R73)
* Changed the Discourse Redis service image from `bitnami/redis:7.0` to the lighter `redis:7-alpine` image.
* Updated the Redmine service image from `docker.io/bitnami/redmine:5` to the official `redmine:5.1.2-alpine` image.
* Changed the Redmine database image from `docker.io/bitnami/mariadb:11.1` to the official `mariadb:11.1` image.