### PR TITLE
Feat/quickfix monica pumperly

### DIFF
--- a/servapps/Discourse/cosmos-compose.json
+++ b/servapps/Discourse/cosmos-compose.json
@@ -4,13 +4,13 @@
       {
         "name": "DISCOURSE_USERNAME",
         "label": "What is your discourse user login?",
-        "initialValue": "Tinyactive",
+        "initialValue": "",
         "type": "text"
       },
       {
         "name": "DISCOURSE_PASSWORD",
         "label": "What discourse password does it use?",
-        "initialValue": "fd4y3Sb4VnUbegrD",
+        "initialValue": "",
         "type": "password"
       }
     ]
@@ -18,7 +18,7 @@
   "minVersion": "0.9.0",
   "services": {
     "{ServiceName}": {
-      "image": "bitnami/discourse:latest",
+      "image": "discourse/discourse:latest",
       "container_name": "{ServiceName}",
       "hostname": "{ServiceName}",
       "restart": "unless-stopped",
@@ -70,7 +70,7 @@
       ]
     },
     "{ServiceName}-sidekiq": {
-      "image": "bitnami/discourse:latest",
+      "image": "discourse/discourse:latest",
       "container_name": "{ServiceName}-sidekiq",
       "hostname": "{ServiceName}-sidekiq",
       "restart": "unless-stopped",
@@ -139,7 +139,7 @@
       ]
     },
     "{ServiceName}-redis": {
-      "image": "bitnami/redis:7.0",
+      "image": "redis:7-alpine",
       "container_name": "{ServiceName}-redis",
       "hostname": "{ServiceName}-redis",
       "restart": "unless-stopped",

--- a/servapps/Monica/cosmos-compose.json
+++ b/servapps/Monica/cosmos-compose.json
@@ -14,7 +14,7 @@
           }
         ],
         "environment": [
-          "APP_KEY=base64:7ZCNatgavRKG9zh67rc2JP+PAUewZA5UABnMgpGSieA=",
+          "APP_KEY={Passwords.0}",
           "DB_PASSWORD={Passwords.1}",
           "DB_HOST={ServiceName}-db",
           "DB_PORT=3306",
@@ -51,7 +51,7 @@
 
       },
       "{ServiceName}-db": {
-        "image": "docker.io/bitnami/mariadb:11.1",
+        "image": "mariadb:11.1",
         "container_name": "{ServiceName}-db",
         "hostname": "{ServiceName}-db",
         "restart": "unless-stopped",
@@ -61,7 +61,7 @@
         "volumes": [
           {
             "source": "{ServiceName}-db",
-            "target": "/bitnami/mariadb",
+            "target": "/var/lib/mysql",
             "type": "volume"
           }
         ],


### PR DESCRIPTION
This pull request updates configuration files for the Discourse and Monica services to improve security and standardize Docker images and volume paths. The main changes focus on removing hardcoded secrets, switching to official images, and aligning volume mounts with the new images.

**Security and configuration improvements:**

* Removed hardcoded default values for `DISCOURSE_USERNAME` and `DISCOURSE_PASSWORD` in `servapps/Discourse/cosmos-compose.json`, requiring users to provide their own credentials.
* Updated Monica's `APP_KEY` environment variable to use a password placeholder instead of a hardcoded value in `servapps/Monica/cosmos-compose.json`.

**Docker image and volume standardization:**

* Changed Discourse and Sidekiq services to use the official `discourse/discourse:latest` Docker image instead of the Bitnami variant in `servapps/Discourse/cosmos-compose.json`. [[1]](diffhunk://#diff-5941aa5950bee58498d55033025d6778f14f4555e839c11a97fe7eb9618250beL7-R21) [[2]](diffhunk://#diff-5941aa5950bee58498d55033025d6778f14f4555e839c11a97fe7eb9618250beL73-R73)
* Updated the Redis service to use the official `redis:7-alpine` image instead of `bitnami/redis:7.0` in `servapps/Discourse/cosmos-compose.json`.
* Changed Monica's database service to use the official `mariadb:11.1` image and updated the volume mount path to `/var/lib/mysql` to match the official image's convention in `servapps/Monica/cosmos-compose.json`. [[1]](diffhunk://#diff-c35dc5dfebcd0f1e53878b64d6628f0f6cb1191b30769033acbd15c2ccc676e6L54-R54) [[2]](diffhunk://#diff-c35dc5dfebcd0f1e53878b64d6628f0f6cb1191b30769033acbd15c2ccc676e6L64-R64)