### PR TITLE
Fix App: FileBrowser Quantum

### DIFF
--- a/servapps/FileBrowserQuantum/artefacts/config.yaml
+++ b/servapps/FileBrowserQuantum/artefacts/config.yaml
@@ -8,7 +8,6 @@ server:
     - path: "/host"
       config:
         defaultEnabled: true
-        disableIndexing: true
       name: "Host"
 
 auth:


### PR DESCRIPTION
FileBrowser Quantum silently broke configs with `disableIndexing: true` in there. As it is deprecated anyway, I removed it from the default config.