### PR TITLE
fix: replace Bitnami image for Dokuwiki

### DIFF
--- a/servapps/Dokuwiki/cosmos-compose.json
+++ b/servapps/Dokuwiki/cosmos-compose.json
@@ -1,63 +1,51 @@
 {
   "cosmos-installer": {
-            "form": [{
-                "name": "DOKUWIKI_USERNAME",
-                "label": "What Dokuwiki do you want to use?",
-                "initialValue": "admin",
-                "type": "text"
-            },
-            {
-                "name": "DOKUWIKI_PASSWORD",
-                "label": "What Dokuwiki admin password do you want?",
-                "initialValue": "password",
-                "type": "password"
-            },
-            {
-                "name": "DOKUWIKI_EMAIL",
-                "label": "What Dokuwiki admin email do you want?",
-                "initialValue": "admin@Dokuwiki.com",
-                "type": "text"
-            }
-        ]
+    "post-install": [
+      {
+        "type": "info",
+        "label": "Open /install.php on first launch to create the initial DokuWiki admin account."
+      }
+    ]
   },
-    "minVersion": "0.8.0",
-    "services": {
-      "{ServiceName}": {
-        "container_name": "{ServiceName}",
-        "hostname": "{ServiceName}",
-        "image": "docker.io/bitnami/dokuwiki",
-        "environment": [
-          "DOKUWIKI_USERNAME={Context.DOKUWIKI_USERNAME}",
-          "DOKUWIKI_PASSWORD={Context.DOKUWIKI_PASSWORD}",
-          "DOKUWIKI_EMAIL={Context.DOKUWIKI_EMAIL}",
-          "PHP_ENABLE_OPCACHE=yes"
+  "minVersion": "0.8.0",
+  "services": {
+    "{ServiceName}": {
+      "image": "lscr.io/linuxserver/dokuwiki:latest",
+      "container_name": "{ServiceName}",
+      "hostname": "{ServiceName}",
+      "restart": "unless-stopped",
+      "UID": 1000,
+      "GID": 1000,
+      "environment": [
+        "PUID=1000",
+        "PGID=1000",
+        "TZ=auto"
       ],
-        "volumes": [
-          {
-            "source": "{ServiceName}-dokuwiki_data",
-            "target": "/bitnami/dokuwiki",
-            "type": "volume"
-          }
-        ],
-        "labels": {
-          "cosmos-persistent-env": "DOKUWIKI_USERNAME, DOKUWIKI_PASSWORD, DOKUWIKI_EMAIL, PHP_ENABLE_OPCACHE",
-          "cosmos-force-network-secured": "true",
-          "cosmos-auto-update": "true",
-          "cosmos-icon": "https://azukaar.github.io/cosmos-servapps-official/Dokuwiki/icon.png"
-        },
-        "routes": [{
+      "volumes": [
+        {
+          "source": "{ServiceName}-config",
+          "target": "/config",
+          "type": "volume"
+        }
+      ],
+      "labels": {
+        "cosmos-force-network-secured": "true",
+        "cosmos-auto-update": "true",
+        "cosmos-icon": "https://azukaar.github.io/cosmos-servapps-official/servapps/Dokuwiki/icon.png"
+      },
+      "routes": [
+        {
           "name": "{ServiceName}",
           "description": "Expose {ServiceName} to the web",
           "useHost": true,
-          "target": "http://{ServiceName}:8080",
+          "target": "http://{ServiceName}:80",
           "mode": "SERVAPP",
           "Timeout": 14400000,
           "ThrottlePerMinute": 12000,
           "BlockCommonBots": true,
-          "SmartShield": {
-              "Enabled": true
-          }
-      }]
-      }
+          "SmartShield": { "Enabled": true }
+        }
+      ]
     }
   }
+}


### PR DESCRIPTION
## Summary
- Replace Bitnami-specific image/configuration assumptions for Dokuwiki.
- Update the Cosmos Compose service definition to use the new image/runtime layout.
- Adjust environment variables, volume paths, commands, and route targets where needed.

## Testing
- Ran `node index.js`.
- Ran `git diff --check`.
- Verified the updated `servapps/Dokuwiki/cosmos-compose.json` contains no `bitnami` references.
- Verified the replacement image manifest is publicly available where applicable.
