### PR TITLE
fix: replace Bitnami image for Drupal

### DIFF
--- a/servapps/Drupal/cosmos-compose.json
+++ b/servapps/Drupal/cosmos-compose.json
@@ -1,105 +1,68 @@
 {
   "cosmos-installer": {
-    "form": [
+    "post-install": [
       {
-        "name": "DRUPAL_USERNAME",
-        "label": "What Drupal username do you want to use?",
-        "initialValue": "user",
-        "type": "text"
-      },
-      {
-        "name": "DRUPAL_PASSWORD",
-        "label": "What Drupal Password do you want to use?",
-        "initialValue": "password",
-        "type": "password"
-      },
-      {
-        "name": "DRUPAL_EMAIL",
-        "label": "What Drupal Email do you want to use?",
-        "initialValue": "admin@Drupal.com",
-        "type": "text"
+        "type": "info",
+        "label": "Complete Drupal's web installer on first launch. Use database host {ServiceName}-db, database drupal, user drupal and the generated database password."
       }
     ]
   },
-    "minVersion": "0.8.0",
-    "services": {
-      "{ServiceName}": {
-        "image": "docker.io/bitnami/drupal:10",
-        "container_name": "{ServiceName}",
-        "hostname": "{ServiceName}",
-        "volumes": [
-          {
-            "source": "{ServiceName}-drupal_data",
-            "target": "/bitnami/drupal",
-            "type": "volume"
-          }
-        ],
-        "environment": [
-          "DRUPAL_DATABASE_PASSWORD={Passwords.1}",
-          "DRUPAL_DATABASE_HOST={ServiceName}-db",
-          "DRUPAL_DATABASE_PORT_NUMBER=3306",
-          "DRUPAL_DATABASE_USER=bn_drupal",
-          "DRUPAL_DATABASE_NAME=bitnami_drupal",
-          "DRUPAL_USERNAME={Context.DRUPAL_USERNAME}",
-          "DRUPAL_PASSWORD={Context.DRUPAL_PASSWORD}",
-          "DRUPAL_EMAIL={Context.DRUPAL_EMAIL}"
-        ],
-        "networks": {
-            "{ServiceName}": {}
-          },
-          "labels": {
-            "cosmos-persistent-env": "DRUPAL_DATABASE_PASSWORD, DRUPAL_DATABASE_HOST, DRUPAL_DATABASE_PORT_NUMBER, DRUPAL_DATABASE_USER, DRUPAL_DATABASE_NAME",
-            "cosmos-force-network-secured": "true",
-            "cosmos-auto-update": "true",
-            "cosmos-icon": "https://azukaar.github.io/cosmos-servapps-official/Redmine/icon.png",
-            "cosmos-stack": "{ServiceName}",
-            "cosmos-stack-main": "{ServiceName}"
-          },
-        "routes": [{
-            "name": "{ServiceName}",
-            "description": "Expose {ServiceName} to the web",
-            "useHost": true,
-            "target": "http://{ServiceName}:8080",
-            "mode": "SERVAPP",
-            "Timeout": 14400000,
-            "ThrottlePerMinute": 12000,
-            "BlockCommonBots": true,
-            "SmartShield": {
-                "Enabled": true
-            }
-        }]
-
+  "minVersion": "0.8.0",
+  "services": {
+    "{ServiceName}": {
+      "image": "drupal:10-apache",
+      "container_name": "{ServiceName}",
+      "hostname": "{ServiceName}",
+      "restart": "unless-stopped",
+      "volumes": [
+        { "source": "{ServiceName}-modules", "target": "/var/www/html/modules", "type": "volume" },
+        { "source": "{ServiceName}-profiles", "target": "/var/www/html/profiles", "type": "volume" },
+        { "source": "{ServiceName}-themes", "target": "/var/www/html/themes", "type": "volume" },
+        { "source": "{ServiceName}-sites", "target": "/var/www/html/sites", "type": "volume" }
+      ],
+      "networks": { "{ServiceName}": {} },
+      "labels": {
+        "cosmos-force-network-secured": "true",
+        "cosmos-auto-update": "true",
+        "cosmos-icon": "https://azukaar.github.io/cosmos-servapps-official/servapps/Drupal/icon.png",
+        "cosmos-stack": "{ServiceName}",
+        "cosmos-stack-main": "{ServiceName}"
       },
-      "{ServiceName}-db": {
-        "image": "docker.io/bitnami/mariadb:11.1",
-        "container_name": "{ServiceName}-db",
-        "hostname": "{ServiceName}-db",
-        "restart": "unless-stopped",
-        "networks": {
-            "{ServiceName}": {}
-          },
-        "volumes": [
-          {
-            "source": "{ServiceName}-db",
-            "target": "/bitnami/mariadb",
-            "type": "volume"
-          }
-        ],
-        "environment": [
-          "MARIADB_DATABASE=bitnami_drupal",
-          "MARIADB_USER=bn_drupal",
-          "MARIADB_PASSWORD={Passwords.1}",
-          "MARIADB_ROOT_PASSWORD={Passwords.2}"
-        ],
-        "labels": {
-          "cosmos-persistent-env": "MARIADB_DATABASE, MARIADB_USER, MARIADB_PASSWORD, MARIADB_ROOT_PASSWORD",
-          "cosmos-force-network-secured": "true",
-          "cosmos-stack": "{ServiceName}",
-          "cosmos-stack-main": "{ServiceName}"
+      "routes": [
+        {
+          "name": "{ServiceName}",
+          "description": "Expose {ServiceName} to the web",
+          "useHost": true,
+          "target": "http://{ServiceName}:80",
+          "mode": "SERVAPP",
+          "Timeout": 14400000,
+          "ThrottlePerMinute": 12000,
+          "BlockCommonBots": true,
+          "SmartShield": { "Enabled": true }
         }
-      }
+      ]
     },
-    "networks": {
-        "{ServiceName}": {}
+    "{ServiceName}-db": {
+      "image": "mariadb:11.4",
+      "container_name": "{ServiceName}-db",
+      "hostname": "{ServiceName}-db",
+      "restart": "unless-stopped",
+      "networks": { "{ServiceName}": {} },
+      "volumes": [
+        { "source": "{ServiceName}-db", "target": "/var/lib/mysql", "type": "volume" }
+      ],
+      "environment": [
+        "MARIADB_DATABASE=drupal",
+        "MARIADB_USER=drupal",
+        "MARIADB_PASSWORD={Passwords.1}",
+        "MARIADB_ROOT_PASSWORD={Passwords.2}"
+      ],
+      "labels": {
+        "cosmos-persistent-env": "MARIADB_DATABASE, MARIADB_USER, MARIADB_PASSWORD, MARIADB_ROOT_PASSWORD",
+        "cosmos-stack": "{ServiceName}",
+        "cosmos-stack-main": "{ServiceName}"
       }
-  }
+    }
+  },
+  "networks": { "{ServiceName}": {} }
+}


### PR DESCRIPTION
## Summary
- Replace Bitnami-specific image/configuration assumptions for Drupal.
- Update the Cosmos Compose service definition to use the new image/runtime layout.
- Adjust environment variables, volume paths, commands, and route targets where needed.

## Testing
- Ran `node index.js`.
- Ran `git diff --check`.
- Verified the updated `servapps/Drupal/cosmos-compose.json` contains no `bitnami` references.
- Verified the replacement image manifest is publicly available where applicable.
