### PR TITLE
fix: replace Bitnami image for Ghost

### DIFF
--- a/servapps/Ghost/cosmos-compose.json
+++ b/servapps/Ghost/cosmos-compose.json
@@ -1,108 +1,77 @@
 {
-    "cosmos-installer": {
-        "form": [{
-                "name": "GHOST_USERNAME",
-                "label": "What Ghost username do you want to use?",
-                "initialValue": "username",
-                "type": "text"
-            },
-            {
-                "name": "GHOST_PASSWORD",
-                "label": "What Ghost password does it use?",
-                "initialValue": "bitnami1",
-                "type": "password"
-            },
-            {
-                "name": "GHOST_EMAIL",
-                "label": "What is your Ghost email login?",
-                "initialValue": "user@example.com",
-                "type": "text"
-            },
-            {
-                "name": "GHOST_HOST",
-                "label": "What is your Ghost run on domain?",
-                "initialValue": "UserName",
-                "type": "text"
-            },
-            {
-                "name": "GHOST_BLOG_TITLE",
-                "label": "What is your Ghost title?",
-                "initialValue": "LastName",
-                "type": "text"
-            }
-        ]
-    },
-    "minVersion": "0.8.0",
-    "services": {
-        "{ServiceName}": {
-            "image": "docker.io/bitnami/ghost:5",
-            "container_name": "{ServiceName}",
-            "hostname": "{ServiceName}",
-            "environment": [
-                "GHOST_USERNAME={Context.GHOST_USERNAME}",
-                "GHOST_PASSWORD={Context.GHOST_PASSWORD}",
-                "GHOST_EMAIL={Context.GHOST_EMAIL}",
-                "GHOST_HOST={Context.GHOST_HOST}",
-                "GHOST_BLOG_TITLE={Context.GHOST_BLOG_TITLE}",
-                "GHOST_DATABASE_HOST={ServiceName}-db",
-                "GHOST_DATABASE_PORT_NUMBER=3306",
-                "GHOST_DATABASE_USER=Ghost",
-                "GHOST_DATABASE_PASSWORD={Passwords.2}",
-                "GHOST_DATABASE_NAME=Ghost"
-            ],
-            "networks": {
-                "{ServiceName}": {}
-            },
-            "labels": {
-                "cosmos-persistent-env": "GHOST_USERNAME, GHOST_PASSWORD, GHOST_EMAIL, GHOST_HOST, GHOST_BLOG_TITLE, GHOST_DATABASE_HOST, GHOST_DATABASE_PORT_NUMBER, GHOST_DATABASE_USER, GHOST_DATABASE_PASSWORD",
-                "cosmos-force-network-secured": "true",
-                "cosmos-auto-update": "true",
-                "cosmos-icon": "https://azukaar.github.io/cosmos-servapps-official/Ghost/icon.png",
-                "cosmos-stack": "{ServiceName}",
-                "cosmos-stack-main": "{ServiceName}"
-            },
-            "routes": [{
-                "name": "{ServiceName}",
-                "description": "Expose {ServiceName} to the web",
-                "useHost": true,
-                "target": "http://{ServiceName}:2368",
-                "mode": "SERVAPP",
-                "Timeout": 14400000,
-                "ThrottlePerMinute": 12000,
-                "BlockCommonBots": true,
-                "SmartShield": {
-                    "Enabled": true
-                }
-            }]
-
-        },
-        "{ServiceName}-db": {
-            "image": "docker.io/bitnami/mysql:8.0",
-            "container_name": "{ServiceName}-db",
-            "hostname": "{ServiceName}-db",
-            "restart": "unless-stopped",
-            "networks": {
-                "{ServiceName}": {}
-            },
-            "volumes": [{
-                "source": "{ServiceName}-db",
-                "target": "/bitnami/mysql",
-                "type": "volume"
-            }],
-            "environment": [
-                "MYSQL_ROOT_PASSWORD={Passwords.3}",
-                "MYSQL_DATABASE=Ghost",
-                "MYSQL_USER=Ghost",
-                "MYSQL_PASSWORD={Passwords.2}"
-            ],
-            "labels": {
-                "cosmos-persistent-env": "MYSQL_ROOT_PASSWORD, MYSQL_DATABASE, MYSQL_USER, MYSQL_PASSWORD",
-                "cosmos-stack": "{ServiceName}",
-                "cosmos-stack-main": "{ServiceName}"
-            }
+  "cosmos-installer": {
+    "form": [
+      {
+        "name": "GHOST_HOST",
+        "label": "Public Ghost hostname",
+        "initialValue": "{Hostnames.{StaticServiceName}.{StaticServiceName}.host}",
+        "type": "text"
+      }
+    ]
+  },
+  "minVersion": "0.8.0",
+  "services": {
+    "{ServiceName}": {
+      "image": "ghost:5-alpine",
+      "container_name": "{ServiceName}",
+      "hostname": "{ServiceName}",
+      "restart": "unless-stopped",
+      "environment": [
+        "NODE_ENV=production",
+        "url=https://{Context.GHOST_HOST}",
+        "database__client=mysql",
+        "database__connection__host={ServiceName}-db",
+        "database__connection__user=ghost",
+        "database__connection__password={Passwords.2}",
+        "database__connection__database=ghost"
+      ],
+      "volumes": [
+        { "source": "{ServiceName}-content", "target": "/var/lib/ghost/content", "type": "volume" }
+      ],
+      "networks": { "{ServiceName}": {} },
+      "labels": {
+        "cosmos-persistent-env": "url, database__connection__password, database__connection__database, database__connection__user",
+        "cosmos-force-network-secured": "true",
+        "cosmos-auto-update": "true",
+        "cosmos-icon": "https://azukaar.github.io/cosmos-servapps-official/servapps/Ghost/icon.png",
+        "cosmos-stack": "{ServiceName}",
+        "cosmos-stack-main": "{ServiceName}"
+      },
+      "routes": [
+        {
+          "name": "{ServiceName}",
+          "description": "Expose {ServiceName} to the web",
+          "useHost": true,
+          "target": "http://{ServiceName}:2368",
+          "mode": "SERVAPP",
+          "Timeout": 14400000,
+          "ThrottlePerMinute": 12000,
+          "BlockCommonBots": true,
+          "SmartShield": { "Enabled": true }
         }
+      ]
     },
-    "networks": {
-        "{ServiceName}": {}
+    "{ServiceName}-db": {
+      "image": "mysql:8.0",
+      "container_name": "{ServiceName}-db",
+      "hostname": "{ServiceName}-db",
+      "restart": "unless-stopped",
+      "networks": { "{ServiceName}": {} },
+      "volumes": [
+        { "source": "{ServiceName}-db", "target": "/var/lib/mysql", "type": "volume" }
+      ],
+      "environment": [
+        "MYSQL_ROOT_PASSWORD={Passwords.3}",
+        "MYSQL_DATABASE=ghost",
+        "MYSQL_USER=ghost",
+        "MYSQL_PASSWORD={Passwords.2}"
+      ],
+      "labels": {
+        "cosmos-persistent-env": "MYSQL_ROOT_PASSWORD, MYSQL_DATABASE, MYSQL_USER, MYSQL_PASSWORD",
+        "cosmos-stack": "{ServiceName}",
+        "cosmos-stack-main": "{ServiceName}"
+      }
     }
+  },
+  "networks": { "{ServiceName}": {} }
 }


### PR DESCRIPTION
## Summary
- Replace Bitnami-specific image/configuration assumptions for Ghost.
- Update the Cosmos Compose service definition to use the new image/runtime layout.
- Adjust environment variables, volume paths, commands, and route targets where needed.

## Testing
- Ran `node index.js`.
- Ran `git diff --check`.
- Verified the updated `servapps/Ghost/cosmos-compose.json` contains no `bitnami` references.
- Verified the replacement image manifest is publicly available where applicable.
