### PR TITLE
fix: replace Bitnami image for Jenkins

### DIFF
--- a/servapps/Jenkins/cosmos-compose.json
+++ b/servapps/Jenkins/cosmos-compose.json
@@ -1,59 +1,42 @@
 {
-    "cosmos-installer": {
-        "form": [{
-                "name": "JENKINS_USERNAME",
-                "label": "What is your Username jenkins login?",
-                "initialValue": "tinyactive",
-                "type": "text"
-            },
-            {
-                "name": "JENKINS_PASSWORD",
-                "label": "What is your password jenkins login?",
-                "initialValue": "tinyactive",
-                "type": "password"
-            },
-            {
-                "name": "JENKINS_EMAIL",
-                "label": "What is your email jenkins login?",
-                "initialValue": "cosmo@tinyactive.net",
-                "type": "text"
-            }
-        ]
-    },
-    "minVersion": "0.9.0",
-    "services": {
-        "{ServiceName}": {
-            "image": "docker.io/bitnami/jenkins",
-            "container_name": "{ServiceName}",
-            "restart": "unless-stopped",
-            "environment": [
-                "JENKINS_PASSWORD={Context.JENKINS_PASSWORD}",
-                "JENKINS_USERNAME={Context.JENKINS_USERNAME}",
-                "JENKINS_EMAIL={Context.JENKINS_EMAIL}"
-            ],
-            "labels": {
-                "cosmos-force-network-secured": "true",
-                "cosmos-auto-update": "true",
-                "cosmos-icon": "https://azukaar.github.io/cosmos-servapps-official/Jenkins/icon.png"
-            },
-            "volumes": [{
-                "source": "{ServiceName}-jenkins_data",
-                "target": "/bitnami/jenkins",
-                "type": "volume"
-            }],
-            "routes": [{
-                "name": "{ServiceName}",
-                "description": "Expose {ServiceName} to the web",
-                "useHost": true,
-                "target": "http://{ServiceName}:8080",
-                "mode": "SERVAPP",
-                "Timeout": 14400000,
-                "ThrottlePerMinute": 12000,
-                "BlockCommonBots": true,
-                "SmartShield": {
-                    "Enabled": true
-                }
-            }]
+  "cosmos-installer": {
+    "post-install": [
+      {
+        "type": "info",
+        "label": "On first launch Jenkins creates an initial admin password in /var/jenkins_home/secrets/initialAdminPassword. Check the container logs or shell into the container to retrieve it."
+      }
+    ]
+  },
+  "minVersion": "0.9.0",
+  "services": {
+    "{ServiceName}": {
+      "image": "jenkins/jenkins:lts",
+      "container_name": "{ServiceName}",
+      "restart": "unless-stopped",
+      "environment": [
+        "JAVA_OPTS=-Djenkins.install.runSetupWizard=true"
+      ],
+      "labels": {
+        "cosmos-force-network-secured": "true",
+        "cosmos-auto-update": "true",
+        "cosmos-icon": "https://azukaar.github.io/cosmos-servapps-official/servapps/Jenkins/icon.png"
+      },
+      "volumes": [
+        { "source": "{ServiceName}-jenkins_home", "target": "/var/jenkins_home", "type": "volume" }
+      ],
+      "routes": [
+        {
+          "name": "{ServiceName}",
+          "description": "Expose {ServiceName} to the web",
+          "useHost": true,
+          "target": "http://{ServiceName}:8080",
+          "mode": "SERVAPP",
+          "Timeout": 14400000,
+          "ThrottlePerMinute": 12000,
+          "BlockCommonBots": true,
+          "SmartShield": { "Enabled": true }
         }
+      ]
     }
+  }
 }


### PR DESCRIPTION
## Summary
- Replace Bitnami-specific image/configuration assumptions for Jenkins.
- Update the Cosmos Compose service definition to use the new image/runtime layout.
- Adjust environment variables, volume paths, commands, and route targets where needed.

## Testing
- Ran `node index.js`.
- Ran `git diff --check`.
- Verified the updated `servapps/Jenkins/cosmos-compose.json` contains no `bitnami` references.
- Verified the replacement image manifest is publicly available where applicable.
