### PR TITLE
fix: replace Bitnami image for MediaWiki

### DIFF
--- a/servapps/MediaWiki/cosmos-compose.json
+++ b/servapps/MediaWiki/cosmos-compose.json
@@ -1,104 +1,65 @@
 {
   "cosmos-installer": {
-    "form": [
+    "post-install": [
       {
-        "name": "MEDIAWIKI_USERNAME",
-        "label": "What mediawiki username do you want to use?",
-        "initialValue": "user",
-        "type": "text"
-      },
-      {
-        "name": "MEDIAWIKI_PASSWORD",
-        "label": "What mediawiki password does it use?",
-        "initialValue": "bitnami1",
-        "type": "password"
-      },
-      {
-        "name": "MEDIAWIKI_EMAIL",
-        "label": "What is your mediawiki email login?",
-        "initialValue": "user@mediawiki.com",
-        "type": "text"
+        "type": "info",
+        "label": "Complete MediaWiki's web installer on first launch. Use database host {ServiceName}-db, database mediawiki, user mediawiki and the generated database password."
       }
     ]
   },
-    "minVersion": "0.8.0",
-    "services": {
-      "{ServiceName}": {
-        "image": "docker.io/bitnami/mediawiki",
-        "container_name": "{ServiceName}",
-        "hostname": "{ServiceName}",
-        "volumes": [
-          {
-            "source": "{ServiceName}-mediawiki",
-            "target": "/bitnami/mediawiki",
-            "type": "volume"
-          }
-        ],
-        "environment": [
-          "MEDIAWIKI_DATABASE_PASSWORD={Passwords.1}",
-          "MEDIAWIKI_DATABASE_HOST={ServiceName}-db",
-          "MEDIAWIKI_DATABASE_PORT_NUMBER=3306",
-          "MEDIAWIKI_DATABASE_USER=bn_mediawiki",
-          "MEDIAWIKI_DATABASE_NAME=bitnami_mediawiki",
-          "MEDIAWIKI_USERNAME={Context.MEDIAWIKI_USERNAME}",
-          "MEDIAWIKI_PASSWORD={Context.MEDIAWIKI_PASSWORD}",
-          "MEDIAWIKI_EMAIL={Context.MEDIAWIKI_EMAIL}"
-        ],
-        "networks": {
-            "{ServiceName}": {}
-          },
-          "labels": {
-            "cosmos-persistent-env": "MEDIAWIKI_DATABASE_PASSWORD, MEDIAWIKI_DATABASE_HOST, MEDIAWIKI_DATABASE_PORT_NUMBER, MEDIAWIKI_DATABASE_USER, MEDIAWIKI_DATABASE_NAME",
-            "cosmos-force-network-secured": "true",
-            "cosmos-auto-update": "true",
-            "cosmos-icon": "https://azukaar.github.io/cosmos-servapps-official/MediaWiki/icon.png",
-            "cosmos-stack": "{ServiceName}",
-            "cosmos-stack-main": "{ServiceName}"
-          },
-        "routes": [{
-            "name": "{ServiceName}",
-            "description": "Expose {ServiceName} to the web",
-            "useHost": true,
-            "target": "http://{ServiceName}:8080",
-            "mode": "SERVAPP",
-            "Timeout": 14400000,
-            "ThrottlePerMinute": 12000,
-            "BlockCommonBots": true,
-            "SmartShield": {
-                "Enabled": true
-            }
-        }]
-
+  "minVersion": "0.8.0",
+  "services": {
+    "{ServiceName}": {
+      "image": "mediawiki:latest",
+      "container_name": "{ServiceName}",
+      "hostname": "{ServiceName}",
+      "restart": "unless-stopped",
+      "volumes": [
+        { "source": "{ServiceName}-images", "target": "/var/www/html/images", "type": "volume" }
+      ],
+      "networks": { "{ServiceName}": {} },
+      "labels": {
+        "cosmos-force-network-secured": "true",
+        "cosmos-auto-update": "true",
+        "cosmos-icon": "https://azukaar.github.io/cosmos-servapps-official/servapps/MediaWiki/icon.png",
+        "cosmos-stack": "{ServiceName}",
+        "cosmos-stack-main": "{ServiceName}"
       },
-      "{ServiceName}-db": {
-        "image": "docker.io/bitnami/mariadb:11.1",
-        "container_name": "{ServiceName}-db",
-        "hostname": "{ServiceName}-db",
-        "restart": "unless-stopped",
-        "networks": {
-            "{ServiceName}": {}
-          },
-        "volumes": [
-          {
-            "source": "{ServiceName}-db",
-            "target": "/bitnami/mariadb",
-            "type": "volume"
-          }
-        ],
-        "environment": [
-          "MARIADB_DATABASE=bitnami_mediawiki",
-          "MARIADB_USER=bn_mediawiki",
-          "MARIADB_PASSWORD={Passwords.1}",
-          "MARIADB_ROOT_PASSWORD={Passwords.2}"
-        ],
-        "labels": {
-          "cosmos-persistent-env": "MARIADB_DATABASE, MARIADB_USER, MARIADB_PASSWORD, MARIADB_ROOT_PASSWORD",
-          "cosmos-stack": "{ServiceName}",
-          "cosmos-stack-main": "{ServiceName}"
+      "routes": [
+        {
+          "name": "{ServiceName}",
+          "description": "Expose {ServiceName} to the web",
+          "useHost": true,
+          "target": "http://{ServiceName}:80",
+          "mode": "SERVAPP",
+          "Timeout": 14400000,
+          "ThrottlePerMinute": 12000,
+          "BlockCommonBots": true,
+          "SmartShield": { "Enabled": true }
         }
-      }
+      ]
     },
-    "networks": {
-        "{ServiceName}": {}
+    "{ServiceName}-db": {
+      "image": "mariadb:11.4",
+      "container_name": "{ServiceName}-db",
+      "hostname": "{ServiceName}-db",
+      "restart": "unless-stopped",
+      "networks": { "{ServiceName}": {} },
+      "volumes": [
+        { "source": "{ServiceName}-db", "target": "/var/lib/mysql", "type": "volume" }
+      ],
+      "environment": [
+        "MARIADB_DATABASE=mediawiki",
+        "MARIADB_USER=mediawiki",
+        "MARIADB_PASSWORD={Passwords.1}",
+        "MARIADB_ROOT_PASSWORD={Passwords.2}"
+      ],
+      "labels": {
+        "cosmos-persistent-env": "MARIADB_DATABASE, MARIADB_USER, MARIADB_PASSWORD, MARIADB_ROOT_PASSWORD",
+        "cosmos-stack": "{ServiceName}",
+        "cosmos-stack-main": "{ServiceName}"
       }
-  }
+    }
+  },
+  "networks": { "{ServiceName}": {} }
+}


### PR DESCRIPTION
## Summary
- Replace Bitnami-specific image/configuration assumptions for MediaWiki.
- Update the Cosmos Compose service definition to use the new image/runtime layout.
- Adjust environment variables, volume paths, commands, and route targets where needed.

## Testing
- Ran `node index.js`.
- Ran `git diff --check`.
- Verified the updated `servapps/MediaWiki/cosmos-compose.json` contains no `bitnami` references.
- Verified the replacement image manifest is publicly available where applicable.
