### PR TITLE
fix: replace Bitnami image for Nextcloud

### DIFF
--- a/servapps/Nextcloud/cosmos-compose.json
+++ b/servapps/Nextcloud/cosmos-compose.json
@@ -158,7 +158,7 @@
     },
 
     "{ServiceName}-redis": {
-      "image": "bitnami/redis:latest",
+      "image": "redis:7-alpine",
       "container_name": "{ServiceName}-redis",
       "hostname": "{ServiceName}-redis",
       "restart": "unless-stopped",
@@ -178,15 +178,12 @@
       "volumes": [
         {
           "source": "{ServiceName}-redis-data",
-          "target": "/bitnami/redis",
+          "target": "/data",
           "type": "volume"
         }
       ],
-      "environment": [
-        "ALLOW_EMPTY_PASSWORD=no",
-        "REDIS_PASSWORD={Passwords.2}",
-        "REDIS_EXTRA_FLAGS=--auto-aof-rewrite-percentage 100 --auto-aof-rewrite-min-size 64mb"
-      ]
+      "command": "redis-server --requirepass {Passwords.2} --appendonly yes --auto-aof-rewrite-percentage 100 --auto-aof-rewrite-min-size 64mb",
+      "environment": []
     }
   },
 


### PR DESCRIPTION
## Summary
- Replace Bitnami-specific image/configuration assumptions for Nextcloud.
- Update the Cosmos Compose service definition to use the new image/runtime layout.
- Adjust environment variables, volume paths, commands, and route targets where needed.

## Testing
- Ran `node index.js`.
- Ran `git diff --check`.
- Verified the updated `servapps/Nextcloud/cosmos-compose.json` contains no `bitnami` references.
- Verified the replacement image manifest is publicly available where applicable.
