### PR TITLE
fix: replace Bitnami image for Opencart

### DIFF
--- a/servapps/Opencart/cosmos-compose.json
+++ b/servapps/Opencart/cosmos-compose.json
@@ -3,108 +3,84 @@
     "post-install": [
       {
         "type": "info",
-        "label": "The default username: user and the default password is: bitnami. You can change these in the admin panel of the application. If you get an http mixed content error, change the HTTP_SERVER on config.php file to https"
+        "label": "OpenCart uses the web installer on first launch. Use database host {ServiceName}-db, database opencart, user opencart, and the generated database password."
       }
     ],
-    "form": [{
-      "name": "OPENCART_USERNAME",
-      "label": "What OpenCart do you want to use?",
-      "initialValue": "admin",
-      "type": "text"
+    "form": []
   },
-  {
-      "name": "OPENCART_PASSWORD",
-      "label": "What OpenCart admin password do you want?",
-      "initialValue": "password",
-      "type": "password"
-  },
-  {
-      "name": "OPENCART_EMAIL",
-      "label": "What OpenCart admin email do you want?",
-      "initialValue": "admin@OpenCart.com",
-      "type": "text"
-  }
-]
-   },
-    "minVersion": "0.8.0",
-    "services": {
-      "{ServiceName}": {
-        "image": "docker.io/bitnami/opencart",
-        "container_name": "{ServiceName}",
-        "hostname": "{ServiceName}",
-        "volumes": [
-          {
-            "source": "{ServiceName}-opencart_data",
-            "target": "/bitnami/opencart",
-            "type": "volume"
-          }
-        ],
-        "environment": [
-          "OPENCART_DATABASE_PASSWORD={Passwords.1}",
-          "OPENCART_DATABASE_HOST={ServiceName}-db",
-          "OPENCART_DATABASE_PORT_NUMBER=3306",
-          "OPENCART_DATABASE_USER=bn_opencart",
-          "OPENCART_DATABASE_NAME=bitnami_opencart",
-          "OPENCART_USERNAME={Context.OPENCART_USERNAME}",
-          "OPENCART_PASSWORD={Context.OPENCART_PASSWORD}",
-          "OPENCART_EMAIL={Context.OPENCART_EMAIL}",
-          "OPENCART_HOST={Hostnames.{StaticServiceName}.{StaticServiceName}.host}"
-        ],
-        "networks": {
-            "{ServiceName}": {}
-          },
-          "labels": {
-            "cosmos-force-network-secured": "true",
-            "cosmos-auto-update": "true",
-            "cosmos-icon": "https://azukaar.github.io/cosmos-servapps-official/Redmine/icon.png",
-            "cosmos-stack": "{ServiceName}",
-            "cosmos-stack-main": "{ServiceName}"
-          },
-        "routes": [{
-            "name": "{ServiceName}",
-            "description": "Expose {ServiceName} to the web",
-            "useHost": true,
-            "target": "http://{ServiceName}:8080",
-            "mode": "SERVAPP",
-            "Timeout": 14400000,
-            "ThrottlePerMinute": 12000,
-            "BlockCommonBots": true,
-            "SmartShield": {
-                "Enabled": true
-            }
-        }]
-
+  "minVersion": "0.8.0",
+  "services": {
+    "{ServiceName}": {
+      "image": "vimagick/opencart:latest",
+      "container_name": "{ServiceName}",
+      "hostname": "{ServiceName}",
+      "restart": "unless-stopped",
+      "depends_on": {
+        "{ServiceName}-db": {}
       },
-      "{ServiceName}-db": {
-        "image": "docker.io/bitnami/mariadb:11.1",
-        "container_name": "{ServiceName}-db",
-        "hostname": "{ServiceName}-db",
-        "restart": "unless-stopped",
-        "networks": {
-            "{ServiceName}": {}
-          },
-        "volumes": [
-          {
-            "source": "{ServiceName}-db",
-            "target": "/bitnami/mariadb",
-            "type": "volume"
-          }
-        ],
-        "environment": [
-          "MARIADB_DATABASE=bitnami_opencart",
-          "MARIADB_USER=bn_opencart",
-          "MARIADB_PASSWORD={Passwords.1}",
-          "MARIADB_ROOT_PASSWORD={Passwords.2}"
-        ],
-        "labels": {
-          "cosmos-persistent-env": "MARIADB_DATABASE, MARIADB_USER, MARIADB_PASSWORD, MARIADB_ROOT_PASSWORD",
-          "cosmos-force-network-secured": "true",
-          "cosmos-stack": "{ServiceName}",
-          "cosmos-stack-main": "{ServiceName}"
-        }
-      }
-    },
-    "networks": {
+      "networks": {
         "{ServiceName}": {}
+      },
+      "volumes": [
+        {
+          "source": "{ServiceName}-opencart-data",
+          "target": "/var/www",
+          "type": "volume"
+        }
+      ],
+      "environment": [],
+      "labels": {
+        "cosmos-force-network-secured": "true",
+        "cosmos-auto-update": "true",
+        "cosmos-icon": "https://azukaar.github.io/cosmos-servapps-official/servapps/Opencart/icon.png",
+        "cosmos-stack": "{ServiceName}",
+        "cosmos-stack-main": "{ServiceName}"
+      },
+      "routes": [
+        {
+          "name": "{ServiceName}",
+          "description": "Expose {ServiceName} to the web",
+          "useHost": true,
+          "target": "http://{ServiceName}:80",
+          "mode": "SERVAPP",
+          "Timeout": 14400000,
+          "ThrottlePerMinute": 12000,
+          "BlockCommonBots": true,
+          "SmartShield": {
+            "Enabled": true
+          }
+        }
+      ]
+    },
+    "{ServiceName}-db": {
+      "image": "mysql:8.0",
+      "container_name": "{ServiceName}-db",
+      "hostname": "{ServiceName}-db",
+      "restart": "unless-stopped",
+      "networks": {
+        "{ServiceName}": {}
+      },
+      "volumes": [
+        {
+          "source": "{ServiceName}-db",
+          "target": "/var/lib/mysql",
+          "type": "volume"
+        }
+      ],
+      "environment": [
+        "MYSQL_DATABASE=opencart",
+        "MYSQL_USER=opencart",
+        "MYSQL_PASSWORD={Passwords.1}",
+        "MYSQL_ROOT_PASSWORD={Passwords.2}"
+      ],
+      "labels": {
+        "cosmos-persistent-env": "MYSQL_DATABASE, MYSQL_USER, MYSQL_PASSWORD, MYSQL_ROOT_PASSWORD",
+        "cosmos-stack": "{ServiceName}",
+        "cosmos-stack-main": "{ServiceName}"
       }
+    }
+  },
+  "networks": {
+    "{ServiceName}": {}
   }
+}


### PR DESCRIPTION
## Summary
- Replace Bitnami-specific image/configuration assumptions for Opencart.
- Update the Cosmos Compose service definition to use the new image/runtime layout.
- Adjust environment variables, volume paths, commands, and route targets where needed.

## Testing
- Ran `node index.js`.
- Ran `git diff --check`.
- Verified the updated `servapps/Opencart/cosmos-compose.json` contains no `bitnami` references.
- Verified the replacement image manifest is publicly available where applicable.
