### PR TITLE
fix: replace Bitnami image for Sonarqube

### DIFF
--- a/servapps/Sonarqube/cosmos-compose.json
+++ b/servapps/Sonarqube/cosmos-compose.json
@@ -1,47 +1,28 @@
 {
   "cosmos-installer": {
-    "form": [
+    "post-install": [
       {
-        "name": "SONARQUBE_USERNAME",
-        "label": "What is your Sonarqube user login?",
-        "initialValue": "admin",
-        "type": "text"
-      },
-      {
-        "name": "SONARQUBE_PASSWORD",
-        "label": "What Sonarqube password does it use?",
-        "initialValue": "bitnami",
-        "type": "password"
-      },
-      {
-        "name": "SONARQUBE_EMAIL",
-        "label": "What Sonarqube email does it use?",
-        "initialValue": "email@Sonarqube.com",
-        "type": "email"
+        "type": "info",
+        "label": "SonarQube default login is admin/admin. You will be asked to change it on first login."
       }
     ]
   },
   "minVersion": "0.9.0",
   "services": {
     "{ServiceName}": {
-      "image": "bitnami/sonarqube:latest",
+      "image": "sonarqube:community",
       "container_name": "{ServiceName}",
       "restart": "unless-stopped",
       "environment": [
-        "SONARQUBE_PASSWORD={Context.SONARQUBE_PASSWORD}",
-        "SONARQUBE_USERNAME={Context.SONARQUBE_USERNAME}",
-        "SONARQUBE_EMAIL={Context.SONARQUBE_EMAIL}",
-        "SONARQUBE_DATABASE_HOST={ServiceName}-postgres",
-        "SONARQUBE_DATABASE_PORT_NUMBER=5432",
-        "SONARQUBE_DATABASE_USER=sonarqube",
-        "SONARQUBE_DATABASE_NAME=sonarqube",
-        "SONARQUBE_DATABASE_PASSWORD={Passwords.0}"
+        "SONAR_JDBC_URL=jdbc:postgresql://{ServiceName}-postgres:5432/sonarqube",
+        "SONAR_JDBC_USERNAME=sonarqube",
+        "SONAR_JDBC_PASSWORD={Passwords.0}"
       ],
       "labels": {
-        "cosmos-persistent-env": "SONARQUBE_DATABASE_PORT_NUMBER, SONARQUBE_DATABASE_USER, SONARQUBE_DATABASE_NAME, SONARQUBE_DATABASE_PASSWORD ",
+        "cosmos-persistent-env": "SONAR_JDBC_URL, SONAR_JDBC_USERNAME, SONAR_JDBC_PASSWORD",
         "cosmos-force-network-secured": "true",
         "cosmos-auto-update": "true",
-        "cosmos-icon": "https://azukaar.github.io/cosmos-servapps-official/Sonarqube/icon.png",
+        "cosmos-icon": "https://azukaar.github.io/cosmos-servapps-official/servapps/Sonarqube/icon.png",
         "cosmos-stack": "{ServiceName}",
         "cosmos-stack-main": "{ServiceName}"
       },
@@ -50,11 +31,21 @@
       },
       "volumes": [
         {
-          "source": "{ServiceName}-sonarqube_data",
-          "target": "/bitnami/sonarqube",
+          "source": "{ServiceName}-sonarqube-data",
+          "target": "/opt/sonarqube/data",
+          "type": "volume"
+        },
+        {
+          "source": "{ServiceName}-sonarqube-logs",
+          "target": "/opt/sonarqube/logs",
+          "type": "volume"
+        },
+        {
+          "source": "{ServiceName}-sonarqube-extensions",
+          "target": "/opt/sonarqube/extensions",
           "type": "volume"
         }
-    ],
+      ],
       "routes": [
         {
           "name": "{ServiceName}",
@@ -71,7 +62,6 @@
         }
       ]
     },
-    
     "{ServiceName}-postgres": {
       "image": "postgres:15-alpine",
       "container_name": "{ServiceName}-postgres",
@@ -104,9 +94,7 @@
       ]
     }
   },
-
   "networks": {
-    "{ServiceName}-postgres": {
-    }
+    "{ServiceName}-postgres": {}
   }
 }


### PR DESCRIPTION
## Summary
- Replace Bitnami-specific image/configuration assumptions for Sonarqube.
- Update the Cosmos Compose service definition to use the new image/runtime layout.
- Adjust environment variables, volume paths, commands, and route targets where needed.

## Testing
- Ran `node index.js`.
- Ran `git diff --check`.
- Verified the updated `servapps/Sonarqube/cosmos-compose.json` contains no `bitnami` references.
- Verified the replacement image manifest is publicly available where applicable.
