### PR TITLE
fix: replace Bitnami image for Suitecrm

### DIFF
--- a/servapps/Suitecrm/cosmos-compose.json
+++ b/servapps/Suitecrm/cosmos-compose.json
@@ -1,106 +1,106 @@
 {
-    "cosmos-installer": {
-        "form": [{
-                "name": "SUITECRM_USERNAME",
-                "label": "What Suitecrm username admin do you want to use?",
-                "initialValue": "user",
-                "type": "text"
-            },
-            {
-                "name": "SUITECRM_PASSWORD",
-                "label": "What Suitecrm password admin does it use?",
-                "initialValue": "password",
-                "type": "password"
-            },
-            {
-                "name": "SUITECRM_EMAIL",
-                "label": "What is your Suitecrm email admin?",
-                "initialValue": "user@example.com",
-                "type": "text"
-            },
-            {
-                "name": "SUITECRM_HOST",
-                "label": "What is your Suitecrm domain?",
-                "initialValue": "example.com",
-                "type": "text"
-            }
-        ]
-    },
-    "minVersion": "0.8.0",
-    "services": {
-        "{ServiceName}": {
-            "image": "bitnami/suitecrm",
-            "container_name": "{ServiceName}",
-            "hostname": "{ServiceName}",
-            "volumes": [{
-                "source": "{ServiceName}-suitecrm",
-                "target": "/bitnami/suitecrm",
-                "type": "volume"
-            }],
-            "environment": [
-                "SUITECRM_DATABASE_PASSWORD={Passwords.1}",
-                "SUITECRM_DATABASE_HOST={ServiceName}-db",
-                "SUITECRM_DATABASE_PORT_NUMBER=3306",
-                "SUITECRM_DATABASE_USER=bn_suitecrm",
-                "SUITECRM_DATABASE_NAME=bitnami_suitecrm",
-                "SUITECRM_USERNAME={Context.SUITECRM_USERNAME}",
-                "SUITECRM_PASSWORD={Context.SUITECRM_PASSWORD}",
-                "SUITECRM_EMAIL={Context.SUITECRM_EMAIL}",
-                "SUITECRM_HOST={Context.SUITECRM_HOST}"
-            ],
-            "networks": {
-                "{ServiceName}": {}
-            },
-            "labels": {
-                "cosmos-persistent-env": "SUITECRM_DATABASE_PASSWORD, SUITECRM_DATABASE_HOST, SUITECRM_DATABASE_PORT_NUMBER, SUITECRM_DATABASE_USER, SUITECRM_DATABASE_NAME",
-                "cosmos-force-network-secured": "true",
-                "cosmos-auto-update": "true",
-                "cosmos-icon": "https://azukaar.github.io/cosmos-servapps-official/Suitecrm/icon.png",
-                "cosmos-stack": "{ServiceName}",
-                "cosmos-stack-main": "{ServiceName}"
-            },
-            "routes": [{
-                "name": "{ServiceName}",
-                "description": "Expose {ServiceName} to the web",
-                "useHost": true,
-                "target": "http://{ServiceName}:8080",
-                "mode": "SERVAPP",
-                "Timeout": 14400000,
-                "ThrottlePerMinute": 12000,
-                "BlockCommonBots": true,
-                "SmartShield": {
-                    "Enabled": true
-                }
-            }]
-
-        },
-        "{ServiceName}-db": {
-            "image": "docker.io/bitnami/mariadb:11.1",
-            "container_name": "{ServiceName}-db",
-            "hostname": "{ServiceName}-db",
-            "restart": "unless-stopped",
-            "networks": {
-                "{ServiceName}": {}
-            },
-            "volumes": [{
-                "source": "{ServiceName}-db",
-                "target": "/bitnami/mariadb",
-                "type": "volume"
-            }],
-            "environment": [
-                "MARIADB_DATABASE=bitnami_suitecrm",
-                "MARIADB_USER=bn_suitecrm",
-                "MARIADB_PASSWORD={Passwords.1}",
-                "MARIADB_ROOT_PASSWORD={Passwords.2}"
-            ],
-            "labels": {
-                "cosmos-persistent-env": "MARIADB_DATABASE, MARIADB_USER, MARIADB_PASSWORD, MARIADB_ROOT_PASSWORD",
-                "cosmos-stack": "{ServiceName}",
-                "cosmos-stack-main": "{ServiceName}"
-            }
+  "cosmos-installer": {
+    "form": [
+      {
+        "name": "SUITECRM_USERNAME",
+        "label": "What SuiteCRM username admin do you want to use?",
+        "initialValue": "admin",
+        "type": "text"
+      },
+      {
+        "name": "SUITECRM_PASSWORD",
+        "label": "What SuiteCRM password admin does it use?",
+        "initialValue": "password",
+        "type": "password"
+      },
+      {
+        "name": "SUITECRM_HOST",
+        "label": "What is your SuiteCRM domain?",
+        "initialValue": "{Hostnames.{StaticServiceName}.{StaticServiceName}.host}",
+        "type": "text"
+      }
+    ]
+  },
+  "minVersion": "0.8.0",
+  "services": {
+    "{ServiceName}": {
+      "image": "guerchele/suitecrm:8-latest",
+      "container_name": "{ServiceName}",
+      "hostname": "{ServiceName}",
+      "volumes": [
+        {
+          "source": "{ServiceName}-suitecrm-state",
+          "target": "/var/lib/suitecrm",
+          "type": "volume"
         }
-    },
-    "networks": {
+      ],
+      "environment": [
+        "DB_HOST={ServiceName}-db",
+        "DB_PORT=3306",
+        "DB_NAME=suitecrm",
+        "DB_USER=suitecrm",
+        "DB_PASSWORD={Passwords.1}",
+        "SITE_URL=https://{Context.SUITECRM_HOST}",
+        "SUITECRM_AUTO_INSTALL=1",
+        "SUITECRM_ADMIN_USER={Context.SUITECRM_USERNAME}",
+        "SUITECRM_ADMIN_PASSWORD={Context.SUITECRM_PASSWORD}"
+      ],
+      "networks": {
         "{ServiceName}": {}
+      },
+      "labels": {
+        "cosmos-persistent-env": "DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASSWORD, SITE_URL, SUITECRM_ADMIN_USER, SUITECRM_ADMIN_PASSWORD",
+        "cosmos-force-network-secured": "true",
+        "cosmos-auto-update": "true",
+        "cosmos-icon": "https://azukaar.github.io/cosmos-servapps-official/servapps/Suitecrm/icon.png",
+        "cosmos-stack": "{ServiceName}",
+        "cosmos-stack-main": "{ServiceName}"
+      },
+      "routes": [
+        {
+          "name": "{ServiceName}",
+          "description": "Expose {ServiceName} to the web",
+          "useHost": true,
+          "target": "http://{ServiceName}:80",
+          "mode": "SERVAPP",
+          "Timeout": 14400000,
+          "ThrottlePerMinute": 12000,
+          "BlockCommonBots": true,
+          "SmartShield": {
+            "Enabled": true
+          }
+        }
+      ]
+    },
+    "{ServiceName}-db": {
+      "image": "mariadb:11.4",
+      "container_name": "{ServiceName}-db",
+      "hostname": "{ServiceName}-db",
+      "restart": "unless-stopped",
+      "networks": {
+        "{ServiceName}": {}
+      },
+      "volumes": [
+        {
+          "source": "{ServiceName}-db",
+          "target": "/var/lib/mysql",
+          "type": "volume"
+        }
+      ],
+      "environment": [
+        "MARIADB_DATABASE=suitecrm",
+        "MARIADB_USER=suitecrm",
+        "MARIADB_PASSWORD={Passwords.1}",
+        "MARIADB_ROOT_PASSWORD={Passwords.2}"
+      ],
+      "labels": {
+        "cosmos-persistent-env": "MARIADB_DATABASE, MARIADB_USER, MARIADB_PASSWORD, MARIADB_ROOT_PASSWORD",
+        "cosmos-stack": "{ServiceName}",
+        "cosmos-stack-main": "{ServiceName}"
+      }
     }
+  },
+  "networks": {
+    "{ServiceName}": {}
+  }
 }


### PR DESCRIPTION
## Summary
- Replace Bitnami-specific image/configuration assumptions for Suitecrm.
- Update the Cosmos Compose service definition to use the new image/runtime layout.
- Adjust environment variables, volume paths, commands, and route targets where needed.

## Testing
- Ran `node index.js`.
- Ran `git diff --check`.
- Verified the updated `servapps/Suitecrm/cosmos-compose.json` contains no `bitnami` references.
- Verified the replacement image manifest is publicly available where applicable.
