### PR TITLE
fix: remove Bitnami assumptions from redmine

### DIFF
--- a/servapps/redmine/cosmos-compose.json
+++ b/servapps/redmine/cosmos-compose.json
@@ -42,16 +42,17 @@
         "volumes": [
           {
             "source": "{ServiceName}-redmine",
-            "target": "/bitnami/redmine",
+            "target": "/usr/src/redmine/files",
             "type": "volume"
           }
         ],
         "environment": [
-          "REDMINE_DATABASE_PASSWORD={Passwords.1}",
-          "REDMINE_DATABASE_HOST={ServiceName}-db",
-          "REDMINE_DATABASE_PORT_NUMBER=3306",
-          "REDMINE_DATABASE_USER=bn_redmine",
-          "REDMINE_DATABASE_NAME=bitnami_redmine",
+          "REDMINE_DB_PASSWORD={Passwords.1}",
+          "REDMINE_DB_MYSQL={ServiceName}-db",
+          "REDMINE_DB_PORT=3306",
+          "REDMINE_DB_USERNAME=redmine",
+          "REDMINE_DB_DATABASE=redmine",
+          "SECRET_KEY_BASE={Passwords.3}",
           "REDMINE_USERNAME={Context.REDMINE_USERNAME}",
           "REDMINE_PASSWORD={Context.REDMINE_PASSWORD}",
           "REDMINE_EMAIL={Context.REDMINE_EMAIL}",
@@ -62,7 +63,7 @@
             "{ServiceName}": {}
           },
           "labels": {
-            "cosmos-persistent-env": "REDMINE_DATABASE_PASSWORD, REDMINE_DATABASE_HOST, REDMINE_DATABASE_USER, REDMINE_DATABASE_NAME, REDMINE_DATABASE_PORT_NUMBER",
+            "cosmos-persistent-env": "REDMINE_DB_PASSWORD, REDMINE_DB_MYSQL, REDMINE_DB_USERNAME, REDMINE_DB_DATABASE, REDMINE_DB_PORT, SECRET_KEY_BASE",
             "cosmos-force-network-secured": "true",
             "cosmos-auto-update": "true",
             "cosmos-icon": "https://azukaar.github.io/cosmos-servapps-official/Redmine/icon.png",
@@ -95,13 +96,13 @@
         "volumes": [
           {
             "source": "{ServiceName}-db",
-            "target": "/bitnami/mariadb",
+            "target": "/var/lib/mysql",
             "type": "volume"
           }
         ],
         "environment": [
-          "MARIADB_DATABASE=bitnami_redmine",
-          "MARIADB_USER=bn_redmine",
+          "MARIADB_DATABASE=redmine",
+          "MARIADB_USER=redmine",
           "MARIADB_PASSWORD={Passwords.1}",
           "MARIADB_ROOT_PASSWORD={Passwords.2}"
         ],


### PR DESCRIPTION
## Summary
- Remove leftover Bitnami-specific paths/configuration from redmine.
- Update volume paths and runtime settings to match the non-Bitnami image layout.

## Testing
- Ran `node index.js`.
- Ran `git diff --check`.
- Verified the updated `servapps/redmine/cosmos-compose.json` contains no `bitnami` references.
- Verified the compose JSON parses successfully.
