### PR TITLE
LibreDB Studio: fix login (JWT_SECRET too short), bump to 0.9.59, declare arm64

### DIFF
--- a/servapps/LibreDB-Studio/cosmos-compose.json
+++ b/servapps/LibreDB-Studio/cosmos-compose.json
@@ -3,7 +3,7 @@
     "minVersion": "0.9.0",
     "services": {
         "{ServiceName}": {
-            "image": "ghcr.io/libredb/libredb-studio:0.9.27",
+            "image": "ghcr.io/libredb/libredb-studio:0.9.59",
             "container_name": "{ServiceName}",
             "restart": "unless-stopped",
             "environment": [
@@ -11,7 +11,7 @@
                 "ADMIN_PASSWORD={Password}",
                 "USER_EMAIL=user@libredb.org",
                 "USER_PASSWORD={Password}",
-                "JWT_SECRET={Password}",
+                "JWT_SECRET={Passwords.0}{Passwords.1}",
                 "STORAGE_PROVIDER=sqlite",
                 "STORAGE_SQLITE_PATH=/app/data/libredb-storage.db"
             ],

--- a/servapps/LibreDB-Studio/description.json
+++ b/servapps/LibreDB-Studio/description.json
@@ -5,5 +5,5 @@
     "tags": ["database", "sql", "developer-tools", "self-hosted"],
     "repository": "https://github.com/libredb/libredb-studio/",
     "image": "https://github.com/libredb/libredb-studio/pkgs/container/libredb-studio",
-    "supported_architectures": ["amd64"]
+    "supported_architectures": ["amd64", "arm64"]
 }


### PR DESCRIPTION
Three changes to the LibreDB Studio servapp.

**1. Login is broken in the published servapp (main reason for this PR).**

The template sets `JWT_SECRET={Password}`. Cosmos generates 24 characters for that placeholder (`randomString(24)` in Cosmos-Server `client/src/pages/servapps/containers/docker-compose.jsx`), but LibreDB Studio requires at least 32 characters for the JWT signing key. The container starts and `/api/db/health` reports healthy, so the install looks fine, but every login returns:

```
HTTP 503
Login is unavailable: the server's JWT_SECRET is too short; it must be at least 32 characters.
```

Reproduced locally with a 24-character value, then fixed by concatenating two generated passwords (48 characters) and confirmed login works:

| | 24 chars (current) | 48 chars (this PR) |
|---|---|---|
| `/api/db/health` | healthy | healthy |
| login | HTTP 503, secret too short | HTTP 200, `{"success":true,"role":"admin"}` |
| saved connection survives restart | not reachable | yes |

**2. Image bumped from 0.9.27 to 0.9.59.** The servapp was 32 releases behind.

**3. `supported_architectures` now lists arm64 as well.** `docker manifest inspect ghcr.io/libredb/libredb-studio:0.9.59` returns both `linux/amd64` and `linux/arm64`; the tests above ran on aarch64.

`minVersion` was left untouched.
