### PR TITLE
force version: Paperless-ngx image version to 2.20

### DIFF
--- a/servapps/Paperless-ngx/cosmos-compose.json
+++ b/servapps/Paperless-ngx/cosmos-compose.json
@@ -92,7 +92,7 @@
     },
     
     "{ServiceName}": {
-      "image": "ghcr.io/paperless-ngx/paperless-ngx:latest",
+      "image": "ghcr.io/paperless-ngx/paperless-ngx:2.20",
       "restart": "unless-stopped",
       "depends_on": {
         "{ServiceName}-db": {},


### PR DESCRIPTION
This is temporary until I know how to create a valid secret out of the market template.

Fixes this: https://github.com/azukaar/cosmos-servapps-official/issues/237