### PR TITLE
fix Apps: add correct shm_size

### DIFF
--- a/servapps/Audacity/cosmos-compose.json
+++ b/servapps/Audacity/cosmos-compose.json
@@ -39,7 +39,7 @@
           "type": "volume"
         }
       ],
-      "shm_size": "1gb",
+      "shm_size": 1073741824,
       "routes": [
         {
           "name": "{ServiceName}",

--- a/servapps/Blender/cosmos-compose.json
+++ b/servapps/Blender/cosmos-compose.json
@@ -39,7 +39,7 @@
           "type": "volume"
         }
       ],
-      "shm_size": "1gb",
+      "shm_size": 1073741824,
       "routes": [
         {
           "name": "{ServiceName}",

--- a/servapps/Firefox/cosmos-compose.json
+++ b/servapps/Firefox/cosmos-compose.json
@@ -39,7 +39,7 @@
           "type": "volume"
         }
       ],
-      "shm_size": "1gb",
+      "shm_size": 1073741824,
       "routes": [
         {
           "name": "{ServiceName}",

--- a/servapps/Frigate-NVR/cosmos-compose.json
+++ b/servapps/Frigate-NVR/cosmos-compose.json
@@ -20,10 +20,10 @@
              "type": "password"
           },
           {
-             "name": "sharedMemory",
-             "label": "How much shared memory in megabytes do you want?",
-             "initialValue": "64mb",
-             "type": "text"
+            "name": "sharedMemory",
+            "label": "How much shared memory in bytes do you want (default is 268435456 = 256MB)?",
+            "initialValue": "268435456",
+            "type": "text"
           },
           {
              "name": "cache",
@@ -39,9 +39,7 @@
           "privileged": true,
           "restart": "unless-stopped",
           "image": "ghcr.io/blakeblackshear/frigate:stable",
-          "shm_size": {
-             "Context.sharedMemory": null
-          },
+          "shm_size": {Context.sharedMemory},
           "devices": [
              "/dev/bus/usb:/dev/bus/usb",
              "/dev/apex_0:/dev/apex_0",

--- a/servapps/Frigate-NVR/cosmos-compose.json
+++ b/servapps/Frigate-NVR/cosmos-compose.json
@@ -39,7 +39,9 @@
           "privileged": true,
           "restart": "unless-stopped",
           "image": "ghcr.io/blakeblackshear/frigate:stable",
-          "shm_size": {Context.sharedMemory},
+          "shm_size": {
+             "Context.sharedMemory": null
+          },
           "devices": [
              "/dev/bus/usb:/dev/bus/usb",
              "/dev/apex_0:/dev/apex_0",

--- a/servapps/Webtop/cosmos-compose.json
+++ b/servapps/Webtop/cosmos-compose.json
@@ -39,7 +39,7 @@
           "type": "volume"
         }
       ],
-      "shm_size": "1gb",
+      "shm_size": 1073741824,
       "routes": [
         {
           "name": "{ServiceName}",


### PR DESCRIPTION
I added support for shm_size (bytes in INT) with this PR: https://github.com/azukaar/Cosmos-Server/pull/567

This PR udpates all shm_size-values in the market to respect the used format.