### PR TITLE
Fix Forgejo minVersion typo

### DIFF
--- a/servapps/Forgejo/cosmos-compose.json
+++ b/servapps/Forgejo/cosmos-compose.json
@@ -7,7 +7,7 @@
       }
     ]
   },
-  "minVersion": "11.0.0",
+  "minVersion": "0.11.0",
   "services": {
     "{ServiceName}": {
       "image": "codeberg.org/forgejo/forgejo:11",


### PR DESCRIPTION
When attempting to install Forgejo we currently get

> This service requires a newer version of Cosmos. Please update Cosmos to install this service.

on the most recent release of Cosmos