### PR TITLE
ci: add servapp validation workflow

### DIFF
--- a/.github/scripts/validate-servapps.js
+++ b/.github/scripts/validate-servapps.js
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+/**
+ * CI validator for cosmos-servapps repositories.
+ *
+ * For every directory under ./servapps it checks:
+ *  1. description.json is valid JSON and has the required fields.
+ *  2. cosmos-compose.json (when present) renders successfully with the SAME
+ *     whiskers template engine + JSON parsing that Cosmos itself uses at
+ *     install time (see client/src/pages/servapps/containers/docker-compose.jsx).
+ *  3. Both files are free of "other store" copy-paste mistakes:
+ *     - icon / artifact URLs pointing at another Cosmos store (e.g. a
+ *       github-pages icon path) instead of this official one
+ *     - references to other stores (resiSTORE, cosmos-servapps-unofficial)
+ *  4. A structural check that a compose file exists for each servapp.
+ *
+ * Exit code is non-zero if any check fails.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const whiskers = require('whiskers');
+
+// Other-store path markers - these indicate a different Cosmos store was
+// copy-pasted from.
+const OTHER_STORE_MARKERS = [
+  /resiSTORE/i,
+  /resi-store/i,
+  /cosmos-servapps-unofficial/i,
+  /cosmos-servapps-(?!official)/i,
+  /servapps-experimental/i,
+  /servapps-dev/i,
+  /store-cosmos\.github\.io/i,
+];
+
+// Personal / other-store hostnames found in the wild.
+const OTHER_STORE_HOSTS = [
+  /\.github\.io\/comos\./i,
+  /manhtuong/i,
+];
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+const errors = [];
+const warnings = [];
+
+function err(app, file, msg) { errors.push('[' + app + '] ' + file + ': ' + msg); }
+function warn(app, file, msg) { warnings.push('[' + app + '] ' + file + ': ' + msg); }
+
+function eachApp() {
+  const dir = 'servapps';
+  if (!fs.existsSync(dir)) return [];
+  return fs.readdirSync(dir)
+    .filter((name) => fs.lstatSync(path.join(dir, name)).isDirectory());
+}
+
+function checkStoreUrls(app, file, text) {
+  const urls = text.match(/https?:\/\/[^\s"'`<>\\]+/g) || [];
+  for (const u of urls) {
+    const lower = u.toLowerCase();
+    for (const marker of OTHER_STORE_MARKERS) {
+      if (marker.test(lower)) {
+        if (lower.includes('azukaar.github.io/cosmos-servapps-official')) continue;
+        err(app, file, 'URL looks copy-pasted from another store: ' + u);
+        break;
+      }
+    }
+    for (const hostRe of OTHER_STORE_HOSTS) {
+      if (hostRe.test(lower)) {
+        err(app, file, 'URL points at another store host: ' + u);
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Per-app checks
+// ---------------------------------------------------------------------------
+
+function checkApp(app) {
+  const base = path.join('servapps', app);
+
+  // ---------- description.json ----------
+  const dfile = path.join(base, 'description.json');
+  if (fs.existsSync(dfile)) {
+    let d = null;
+    try { d = JSON.parse(fs.readFileSync(dfile, 'utf8')); }
+    catch (e) { err(app, 'description.json', 'invalid JSON: ' + e.message); }
+
+    if (d) {
+      ['name', 'description', 'longDescription', 'tags', 'repository', 'image', 'supported_architectures'].forEach((field) => {
+        if (d[field] === undefined) err(app, 'description.json', 'missing required field "' + field + '"');
+      });
+      if (Array.isArray(d.tags) && d.tags.length === 0) warn(app, 'description.json', 'tags is empty');
+      checkStoreUrls(app, 'description.json', JSON.stringify(d.repository || '') + ' ' + JSON.stringify(d.image || ''));
+    }
+  } else {
+    err(app, 'description.json', 'description.json is required for every servapp');
+  }
+
+  // ---------- cosmos-compose.json ----------
+  const cfile = path.join(base, 'cosmos-compose.json');
+  if (fs.existsSync(cfile)) {
+    const raw = fs.readFileSync(cfile, 'utf8');
+    const trimmed = raw.trim();
+    const isJson = trimmed.startsWith('{') && trimmed.endsWith('}');
+
+    // Same context object Cosmos builds in docker-compose.jsx
+    const context = {
+      ServiceName: 'TestSvc',
+      Hostnames: [],
+      Context: {},
+      Passwords: { '0': 'pw0', '1': 'pw1', '2': 'pw2', '3': 'pw3', '4': 'pw4' },
+      CPU_ARCH: 'x64',
+      CPU_AVX: 'true',
+      DefaultDataPath: '/cosmos-storage',
+      RootHostname: 'localhost',
+      RootProtocol: 'https',
+    };
+
+    let rendered = null;
+    try {
+      rendered = whiskers.render(raw, context);
+    } catch (e) {
+      err(app, 'cosmos-compose.json', 'whiskers render failed: ' + String(e.message).split('\n')[0]);
+    }
+
+    if (rendered !== null) {
+      if (isJson) {
+        try { JSON.parse(rendered); }
+        catch (e) {
+          err(app, 'cosmos-compose.json', 'rendered output is not valid JSON: ' + String(e.message).split('\n')[0]);
+        }
+      }
+      checkStoreUrls(app, 'cosmos-compose.json', raw);
+    }
+  } else {
+    const yfile = path.join(base, 'docker-compose.yml');
+    if (!fs.existsSync(yfile)) {
+      err(app, 'cosmos-compose.json / docker-compose.yml', 'a compose file is required for every servapp');
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+const only = process.argv[2];
+const apps = only ? [only] : eachApp();
+apps.forEach(checkApp);
+
+const hasErr = errors.length > 0;
+if (warnings.length) {
+  console.log('\n' + warnings.length + ' warning(s):');
+  warnings.forEach((w) => console.log('  [warn] ' + w));
+}
+if (errors.length) {
+  console.log('\n' + errors.length + ' error(s):');
+  errors.forEach((e) => console.log('  [error] ' + e));
+}
+console.log('\nChecked ' + apps.length + ' app(s).');
+process.exit(hasErr ? 1 : 0);

--- a/.github/scripts/validate-servapps.js
+++ b/.github/scripts/validate-servapps.js
@@ -68,9 +68,9 @@ const OWN_STORE_BASE = detectOwnStoreBase();
 // Configuration
 // ---------------------------------------------------------------------------
 
-// No blacklist here by design: we whitelist the URL bases this repository
-// legitimately ships icons/artefacts from (see isAllowedIconUrl below). Any
-// icon/artefact URL that is not under one of those whitelisted bases is
+// No blacklist here by design. We whitelist the URL base this repository
+// ships its icons (and any store-hosted artefact files) from, via
+// isAllowedIconUrl below. Any icon URL not under that whitelisted base is
 // treated as copy-pasted from another store and flagged.
 
 // ---------------------------------------------------------------------------
@@ -90,11 +90,11 @@ function eachApp() {
     .filter((name) => fs.lstatSync(path.join(dir, name)).isDirectory());
 }
 
-// Whitelist of URL bases this repository legitimately ships icons/artefacts
-// from. Anything not under one of these bases is treated as a copy-paste from
-// another store and flagged.
+// Whitelist of URL bases this repository legitimately ships icons from
+// (store-hosted artefact files fall under the same base). Anything else is
+// treated as a copy-paste from another store and flagged.
 function isAllowedIconUrl(lower) {
-  // Only the canonical, actually-served icon/artefact bases are whitelisted.
+  // Only the canonical, actually-served icon bases are whitelisted.
   // (All other forms, e.g. a bare apps/<app>/icon.png under the repo root,
   //  resolve to 404 and must be fixed, not allowed.)
   // 1. This repository's own GitHub Pages store base (e.g. .../servapps/).
@@ -108,15 +108,15 @@ function isAllowedIconUrl(lower) {
   return false;
 }
 
-// Check a single icon/artefact URL. URLs are only validated when they are the
-// store-provided icon/artefact reference (cosmos-icon); all other URLs in an
-// app (repository, image hints, homepages, config defaults) are intentionally
-// skipped and never validated here.
+// Check a single store-served URL (an icon or a store-hosted artefact file).
+// Only these are validated; every other URL in an app (repository, image
+// hints, homepages, config defaults) is intentionally skipped and never
+// checked.
 function checkIconUrl(app, file, url) {
   const lower = (url || '').toLowerCase().trim();
   if (!lower) return;
   if (isAllowedIconUrl(lower)) return;
-  err(app, file, 'icon/artefact URL is not served by this store (copy-paste?): ' + url);
+  err(app, file, 'store icon URL is not served by this store (copy-paste?): ' + url);
 }
 
 // ---------------------------------------------------------------------------
@@ -139,7 +139,7 @@ function checkApp(app) {
       });
       if (Array.isArray(d.tags) && d.tags.length === 0) warn(app, 'description.json', 'tags is empty');
       // NB: description.json URLs (repository / image hints) are intentionally
-      // NOT validated here - only the store-provided icon/artefact URL in the
+      // NOT validated here - only the store-provided icon URL (and store-hosted artefact files) in the
       // compose file is checked (see checkIconUrl below).
     }
   } else {
@@ -180,7 +180,7 @@ function checkApp(app) {
           err(app, 'cosmos-compose.json', 'rendered output is not valid JSON: ' + String(e.message).split('\n')[0]);
         }
       }
-      // Only icon/artefact URLs are validated against the whitelist; every
+      // Only store-served icon URLs and store-hosted artefact URLs are validated against the whitelist; every
       // other URL in the compose file (homepages, config defaults, app 3rd
       // -party sources) is intentionally skipped.
       // 1) cosmos-icon references.

--- a/.github/scripts/validate-servapps.js
+++ b/.github/scripts/validate-servapps.js
@@ -68,23 +68,10 @@ const OWN_STORE_BASE = detectOwnStoreBase();
 // Configuration
 // ---------------------------------------------------------------------------
 
-// Other-store path markers - these indicate a different Cosmos store was
-// copy-pasted from.
-const OTHER_STORE_MARKERS = [
-  /resiSTORE/i,
-  /resi-store/i,
-  /cosmos-servapps-unofficial/i,
-  /cosmos-servapps-(?!official)/i,
-  /servapps-experimental/i,
-  /servapps-dev/i,
-  /store-cosmos\.github\.io/i,
-];
-
-// Personal / other-store hostnames found in the wild.
-const OTHER_STORE_HOSTS = [
-  /\.github\.io\/comos\./i,
-  /manhtuong/i,
-];
+// No blacklist here by design: we whitelist the URL bases this repository
+// legitimately ships icons/artefacts from (see isAllowedIconUrl below). Any
+// icon/artefact URL that is not under one of those whitelisted bases is
+// treated as copy-pasted from another store and flagged.
 
 // ---------------------------------------------------------------------------
 // State
@@ -103,31 +90,30 @@ function eachApp() {
     .filter((name) => fs.lstatSync(path.join(dir, name)).isDirectory());
 }
 
-function isOwnStoreUrl(lower) {
+// Whitelist of URL bases this repository legitimately ships icons/artefacts
+// from. Anything not under one of these bases is treated as a copy-paste from
+// another store and flagged.
+function isAllowedIconUrl(lower) {
+  // 1. This repository's own GitHub Pages store base (e.g. .../servapps/).
   if (OWN_STORE_BASE && lower.startsWith(OWN_STORE_BASE)) return true;
-  // Also treat the canonical official cosmos-servapps-official base as
-  // legitimate, since this repo descends from it.
-  if (lower.startsWith('https://azukaar.github.io/cosmos-servapps-official/servapps/')) return true;
+  // 2. The canonical official cosmos-servapps-official Pages base. Accept both
+  //    the "/servapps/" form and the legacy "<app>/icon.png" form that some
+  //    apps historically used directly under the repo base.
+  if (lower.startsWith('https://azukaar.github.io/cosmos-servapps-official/')) return true;
+  // 3. Official raw.githubusercontent.com artefact base (master branch).
+  if (lower.startsWith('https://raw.githubusercontent.com/azukaar/cosmos-servapps-official/master/')) return true;
   return false;
 }
 
-function checkStoreUrls(app, file, text) {
-  const urls = text.match(/https?:\/\/[^\s"'`<>\\]+/g) || [];
-  for (const u of urls) {
-    const lower = u.toLowerCase();
-    if (isOwnStoreUrl(lower)) continue;
-    for (const marker of OTHER_STORE_MARKERS) {
-      if (marker.test(lower)) {
-        err(app, file, 'URL looks copy-pasted from another store: ' + u);
-        break;
-      }
-    }
-    for (const hostRe of OTHER_STORE_HOSTS) {
-      if (hostRe.test(lower)) {
-        err(app, file, 'URL points at another store host: ' + u);
-      }
-    }
-  }
+// Check a single icon/artefact URL. URLs are only validated when they are the
+// store-provided icon/artefact reference (cosmos-icon); all other URLs in an
+// app (repository, image hints, homepages, config defaults) are intentionally
+// skipped and never validated here.
+function checkIconUrl(app, file, url) {
+  const lower = (url || '').toLowerCase().trim();
+  if (!lower) return;
+  if (isAllowedIconUrl(lower)) return;
+  err(app, file, 'icon/artefact URL is not served by this store (copy-paste?): ' + url);
 }
 
 // ---------------------------------------------------------------------------
@@ -149,7 +135,9 @@ function checkApp(app) {
         if (d[field] === undefined) err(app, 'description.json', 'missing required field "' + field + '"');
       });
       if (Array.isArray(d.tags) && d.tags.length === 0) warn(app, 'description.json', 'tags is empty');
-      checkStoreUrls(app, 'description.json', JSON.stringify(d.repository || '') + ' ' + JSON.stringify(d.image || ''));
+      // NB: description.json URLs (repository / image hints) are intentionally
+      // NOT validated here - only the store-provided icon/artefact URL in the
+      // compose file is checked (see checkIconUrl below).
     }
   } else {
     err(app, 'description.json', 'description.json is required for every servapp');
@@ -189,7 +177,13 @@ function checkApp(app) {
           err(app, 'cosmos-compose.json', 'rendered output is not valid JSON: ' + String(e.message).split('\n')[0]);
         }
       }
-      checkStoreUrls(app, 'cosmos-compose.json', raw);
+      // Only icon/artefact URLs (cosmos-icon) are validated against the
+      // whitelist; every other URL in the compose file is intentionally skipped.
+      const iconRe = /"cosmos-icon"\s*:\s*"([^"]+)"/g;
+      let im;
+      while ((im = iconRe.exec(raw)) !== null) {
+        checkIconUrl(app, 'cosmos-compose.json', im[1]);
+      }
     }
   } else {
     const yfile = path.join(base, 'docker-compose.yml');

--- a/.github/scripts/validate-servapps.js
+++ b/.github/scripts/validate-servapps.js
@@ -8,9 +8,11 @@
  *     whiskers template engine + JSON parsing that Cosmos itself uses at
  *     install time (see client/src/pages/servapps/containers/docker-compose.jsx).
  *  3. Both files are free of "other store" copy-paste mistakes:
- *     - icon / artifact URLs pointing at another Cosmos store (e.g. a
- *       github-pages icon path) instead of this official one
+ *     - icon / artifact URLs pointing at another Cosmos store
  *     - references to other stores (resiSTORE, cosmos-servapps-unofficial)
+ *     URLs under THIS repository's own Pages base
+ *     (https://<owner>.github.io/<repo>/servapps/...) are treated as
+ *     legitimate and not flagged.
  *  4. A structural check that a compose file exists for each servapp.
  *
  * Exit code is non-zero if any check fails.
@@ -20,6 +22,51 @@
 const fs = require('fs');
 const path = require('path');
 const whiskers = require('whiskers');
+
+// ---------------------------------------------------------------------------
+// Determine the "own store" base URL - i.e. this repository's own GitHub
+// Pages URL (e.g. https://<owner>.github.io/<repo>/servapps/...). URLs under
+// this base are considered legitimate (they reference this repo's own store)
+// and are NOT flagged as copy-pasted from another store.
+//
+// In CI, GITHUB_REPOSITORY is set to "owner/repo". Locally we fall back to the
+// git remote. If we can't determine it, we return null.
+// ---------------------------------------------------------------------------
+
+function detectOwnStoreBase() {
+  try {
+    let owner = null;
+    let repo = null;
+
+    if (process.env.GITHUB_REPOSITORY) {
+      const parts = process.env.GITHUB_REPOSITORY.split('/');
+      owner = parts[0];
+      repo = parts[1];
+    } else {
+      const remote = require('child_process')
+        .execSync('git config --get remote.origin.url || true', { encoding: 'utf8' })
+        .trim();
+      const m = remote.match(/(?:github\.com[/:])([^/]+)\/([^./]+?)(?:\.git)?$/);
+      if (m) {
+        owner = m[1];
+        repo = m[2];
+      }
+    }
+
+    if (owner && repo) {
+      return 'https://' + owner.toLowerCase() + '.github.io/' + repo.toLowerCase() + '/servapps/';
+    }
+  } catch (e) {
+    // ignore
+  }
+  return null;
+}
+
+const OWN_STORE_BASE = detectOwnStoreBase();
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
 
 // Other-store path markers - these indicate a different Cosmos store was
 // copy-pasted from.
@@ -56,13 +103,21 @@ function eachApp() {
     .filter((name) => fs.lstatSync(path.join(dir, name)).isDirectory());
 }
 
+function isOwnStoreUrl(lower) {
+  if (OWN_STORE_BASE && lower.startsWith(OWN_STORE_BASE)) return true;
+  // Also treat the canonical official cosmos-servapps-official base as
+  // legitimate, since this repo descends from it.
+  if (lower.startsWith('https://azukaar.github.io/cosmos-servapps-official/servapps/')) return true;
+  return false;
+}
+
 function checkStoreUrls(app, file, text) {
   const urls = text.match(/https?:\/\/[^\s"'`<>\\]+/g) || [];
   for (const u of urls) {
     const lower = u.toLowerCase();
+    if (isOwnStoreUrl(lower)) continue;
     for (const marker of OTHER_STORE_MARKERS) {
       if (marker.test(lower)) {
-        if (lower.includes('azukaar.github.io/cosmos-servapps-official')) continue;
         err(app, file, 'URL looks copy-pasted from another store: ' + u);
         break;
       }

--- a/.github/scripts/validate-servapps.js
+++ b/.github/scripts/validate-servapps.js
@@ -101,8 +101,10 @@ function isAllowedIconUrl(lower) {
   if (OWN_STORE_BASE && lower.startsWith(OWN_STORE_BASE)) return true;
   // 2. The canonical official cosmos-servapps-official Pages base (/servapps/).
   if (lower.startsWith('https://azukaar.github.io/cosmos-servapps-official/servapps/')) return true;
-  // 3. Official raw.githubusercontent.com artefact base (master branch).
+  // 3. Official raw.githubusercontent.com artefact base. Both master and
+  //    unstable branches are valid (an unstable branch is planned).
   if (lower.startsWith('https://raw.githubusercontent.com/azukaar/cosmos-servapps-official/master/servapps/')) return true;
+  if (lower.startsWith('https://raw.githubusercontent.com/azukaar/cosmos-servapps-official/unstable/servapps/')) return true;
   return false;
 }
 
@@ -178,12 +180,21 @@ function checkApp(app) {
           err(app, 'cosmos-compose.json', 'rendered output is not valid JSON: ' + String(e.message).split('\n')[0]);
         }
       }
-      // Only icon/artefact URLs (cosmos-icon) are validated against the
-      // whitelist; every other URL in the compose file is intentionally skipped.
+      // Only icon/artefact URLs are validated against the whitelist; every
+      // other URL in the compose file (homepages, config defaults, app 3rd
+      // -party sources) is intentionally skipped.
+      // 1) cosmos-icon references.
       const iconRe = /"cosmos-icon"\s*:\s*"([^"]+)"/g;
       let im;
       while ((im = iconRe.exec(raw)) !== null) {
         checkIconUrl(app, 'cosmos-compose.json', im[1]);
+      }
+      // 2) Store-hosted artefact URLs (usually wget'd in post-install steps,
+      //    e.g. .../servapps/<App>/artefacts/<file>).
+      const artefactRe = /https?:\/\/[^\s"'`<>\\]*(?:\/artefact|\/artifact)[^\s"'`<>\\]*/gi;
+      let am;
+      while ((am = artefactRe.exec(raw)) !== null) {
+        checkIconUrl(app, 'cosmos-compose.json', am[0]);
       }
     }
   } else {

--- a/.github/scripts/validate-servapps.js
+++ b/.github/scripts/validate-servapps.js
@@ -94,14 +94,15 @@ function eachApp() {
 // from. Anything not under one of these bases is treated as a copy-paste from
 // another store and flagged.
 function isAllowedIconUrl(lower) {
+  // Only the canonical, actually-served icon/artefact bases are whitelisted.
+  // (All other forms, e.g. a bare apps/<app>/icon.png under the repo root,
+  //  resolve to 404 and must be fixed, not allowed.)
   // 1. This repository's own GitHub Pages store base (e.g. .../servapps/).
   if (OWN_STORE_BASE && lower.startsWith(OWN_STORE_BASE)) return true;
-  // 2. The canonical official cosmos-servapps-official Pages base. Accept both
-  //    the "/servapps/" form and the legacy "<app>/icon.png" form that some
-  //    apps historically used directly under the repo base.
-  if (lower.startsWith('https://azukaar.github.io/cosmos-servapps-official/')) return true;
+  // 2. The canonical official cosmos-servapps-official Pages base (/servapps/).
+  if (lower.startsWith('https://azukaar.github.io/cosmos-servapps-official/servapps/')) return true;
   // 3. Official raw.githubusercontent.com artefact base (master branch).
-  if (lower.startsWith('https://raw.githubusercontent.com/azukaar/cosmos-servapps-official/master/')) return true;
+  if (lower.startsWith('https://raw.githubusercontent.com/azukaar/cosmos-servapps-official/master/servapps/')) return true;
   return false;
 }
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,25 +1,33 @@
 name: Validate Servapps
 
-# Runs the servapp validation suite on pull requests and pushes to master.
+# Runs the servapp validation suite on pull requests and pushes to the
+# main branches (master and unstable).
 #
 # What it checks (see .github/scripts/validate-servapps.js):
 #   1. description.json is valid JSON and has all required fields.
 #   2. cosmos-compose.json renders with the same whiskers engine + JSON
 #      parsing that Cosmos uses at install time.
-#   3. No copy-pasted URLs from other stores (resiSTORE, unofficial, etc).
+#   3. No copy-pasted URLs from other stores (e.g. a different Cosmos store
+#      like resiSTORE, "cosmos-servapps-unofficial", etc).
 #   4. A compose file exists for every servapp.
 #
-# By default only servapp directories changed in the diff are validated, so
-# pre-existing issues in unrelated apps do not block PRs. A manual run
+# By default only the servapp directories changed in the diff are validated,
+# so pre-existing issues in unrelated apps do not block PRs. A manual run
 # (workflow_dispatch) validates the entire repository.
 
 on:
   pull_request:
-    branches: ["master"]
-    paths: ["servapps/**"]
+    branches:
+      - master
+      - unstable
+    paths:
+      - 'servapps/**'
   push:
-    branches: ["master"]
-    paths: ["servapps/**"]
+    branches:
+      - master
+      - unstable
+    paths:
+      - 'servapps/**'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,110 @@
+name: Validate Servapps
+
+# Runs the servapp validation suite on pull requests and pushes to master.
+#
+# What it checks (see .github/scripts/validate-servapps.js):
+#   1. description.json is valid JSON and has all required fields.
+#   2. cosmos-compose.json renders with the same whiskers engine + JSON
+#      parsing that Cosmos uses at install time.
+#   3. No copy-pasted URLs from other stores (resiSTORE, unofficial, etc).
+#   4. A compose file exists for every servapp.
+#
+# By default only servapp directories changed in the diff are validated, so
+# pre-existing issues in unrelated apps do not block PRs. A manual run
+# (workflow_dispatch) validates the entire repository.
+
+on:
+  pull_request:
+    branches: ["master"]
+    paths: ["servapps/**"]
+  push:
+    branches: ["master"]
+    paths: ["servapps/**"]
+  workflow_dispatch:
+
+concurrency:
+  group: validate-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          # Fetch all history so we can diff against the base for PRs.
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Install dependencies
+        run: npm ci || npm install
+
+      - name: Determine changed servapp directories
+        id: changed
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+            HEAD="${{ github.event.pull_request.head.sha }}"
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            BASE="$(git rev-parse HEAD~1 2>/dev/null || echo '${{ github.sha }}')"
+            HEAD="${{ github.sha }}"
+          else
+            # workflow_dispatch: full repository
+            echo "changed=ALL" >> "$GITHUB_OUTPUT"
+            echo "Manual full-repo validation requested."
+            exit 0
+          fi
+
+          CHANGED=$(git diff --name-only "$BASE" "$HEAD" -- servapps/ \
+            | sed -E 's#^servapps/([^/]+)/.*#\1#' | sort -u)
+
+          if [ -z "$CHANGED" ]; then
+            echo "No servapp directories changed."
+            echo "changed=" >> "$GITHUB_OUTPUT"
+          else
+            LIST=""
+            for d in $CHANGED; do
+              case " $LIST " in
+                *" $d "*) ;;
+                *) LIST="$LIST $d" ;;
+              esac
+            done
+            echo "changed=${LIST## }" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Validate changed servapps
+        run: |
+          CHANGED="${{ steps.changed.outputs.changed }}"
+          if [ "$CHANGED" = "ALL" ]; then
+            echo "== Validating entire repository =="
+            node .github/scripts/validate-servapps.js \
+              || { echo "::error::Servapp validation failed. See the report above."; exit 1; }
+            exit 0
+          fi
+          if [ -z "$CHANGED" ]; then
+            echo "No servapp changes to validate."
+            exit 0
+          fi
+          FAIL=0
+          for d in $CHANGED; do
+            if [ ! -d "servapps/$d" ]; then
+              echo "::warning::servapps/$d was deleted in this PR; skipping."
+              continue
+            fi
+            echo "== Validating servapps/$d =="
+            if ! node .github/scripts/validate-servapps.js "$d"; then
+              FAIL=1
+              echo "::error file=servapps/$d::Validation failed for servapps/$d"
+            fi
+          done
+          if [ "$FAIL" = "1" ]; then
+            exit 1
+          fi

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,14 +20,10 @@ on:
     branches:
       - master
       - unstable
-    paths:
-      - 'servapps/**'
   push:
     branches:
       - master
       - unstable
-    paths:
-      - 'servapps/**'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,10 +20,14 @@ on:
     branches:
       - master
       - unstable
+    paths:
+      - 'servapps/**'
   push:
     branches:
       - master
       - unstable
+    paths:
+      - 'servapps/**'
   workflow_dispatch:
 
 concurrency:

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ servapps.json
 index.json
 servapps_test.json
 todo.txt
+node_modules/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,24 @@
+{
+  "name": "cosmos-servapps-official",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cosmos-servapps-official",
+      "version": "1.0.0",
+      "devDependencies": {
+        "whiskers": "^0.4.0"
+      }
+    },
+    "node_modules/whiskers": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/whiskers/-/whiskers-0.4.0.tgz",
+      "integrity": "sha512-pTygA/fE6RIMOp3AwUy7E9jrdpqUEa4k5VCdJIBZ/64kNtiMuCTCYC6fzbiUhjxN32zX+qZQlZACMC/un5HS7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cosmos-servapps-official",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Official Cosmos servapp repository",
+  "scripts": {
+    "validate": "node .github/scripts/validate-servapps.js"
+  },
+  "devDependencies": {
+    "whiskers": "^0.4.0"
+  }
+}


### PR DESCRIPTION
## Summary
Adds a GitHub Actions workflow that validates servapps on pull requests/pushes (plus a manual `workflow_dispatch`).

## What it checks
For each changed servapp, `.github/scripts/validate-servapps.js` verifies:
1. `description.json` is valid JSON with all required fields
2. `cosmos-compose.json` renders with the same whiskers engine Cosmos uses at install time
3. No copy-pasted URLs for icons and artefacts from other stores (resiSTORE, cosmos-servapps-unofficial)
4. A compose file exists for every servapp

This exact workflow was tested end-to-end on a fork before submitting upstream.

There are two test PR's which tested this action:
https://github.com/aseracorp/resiSTORE/pull/16 should PASS
https://github.com/aseracorp/resiSTORE/pull/17 should FAIL