### PR TITLE
Fixup: ci: deploy master and unstable branches to GitHub Pages - #275

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -23,10 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Checkout unstable
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: unstable
           path: unstable
@@ -50,6 +50,9 @@ jobs:
 
       - name: Build static files
         run: node index.js && cd unstable && node index.js
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5


### PR DESCRIPTION
fixup: A missing step to setup pages got lost.

Ports the unstable subpath deployment logic from aseracorp/resiSTORE into cosmos-servapps-official, so the unstable branch is served under a /unstable/ subpath.