### PR TITLE
ci: diff against merge-base to detect changed servapps

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -59,8 +59,10 @@ jobs:
         id: changed
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE="${{ github.event.pull_request.base.sha }}"
             HEAD="${{ github.event.pull_request.head.sha }}"
+            # Diff against the merge-base, not the live base tip, so we only
+            # validate the PR's own changes (not apps added to base after the PR branched).
+            BASE="$(git merge-base "$HEAD" "${{ github.event.pull_request.base.sha }}")"
           elif [ "${{ github.event_name }}" = "push" ]; then
             BASE="$(git rev-parse HEAD~1 2>/dev/null || echo '${{ github.sha }}')"
             HEAD="${{ github.sha }}"


### PR DESCRIPTION
## Summary
Fixes the Validate Servapps CI incorrectly flagging many unrelated servapps as 'changed' on PRs whose head branch is behind the base branch.

## Root cause
The workflow determined changed apps with:
```yaml
WITHIN determine-changed step:
  BASE="${{ github.event.pull_request.base.sha }}"   # the *live* base branch tip
  CHANGED=$(git diff --name-only $BASE $HEAD -- servapps/)
```
`base.sha` is the base branch's current tip, **not** the merge-base. When master advances after a PR branches off it, `git diff base_tip..head` includes all of master's own new apps, so a PR that adds a single app gets validated against many phantom apps. Example: PR #245 (ddns-updater) was reported as changing 20 servapps when only `ddns-updater` actually changed.

## Fix
Diff from the merge-base of head and base:
```yaml
BASE="$(git merge-base "$HEAD" "${{ github.event.pull_request.base.sha }}")"
```
This isolates exactly the PR's own changes. Verified locally: buggy logic reported 20 apps, fixed logic reports exactly `ddns-updater`.