### PR TITLE
ci: validate required servapp file structure (icon.png + screenshots/)

### DIFF
--- a/.github/scripts/validate-servapps.js
+++ b/.github/scripts/validate-servapps.js
@@ -14,6 +14,10 @@
  *     (https://<owner>.github.io/<repo>/servapps/...) are treated as
  *     legitimate and not flagged.
  *  4. A structural check that a compose file exists for each servapp.
+ *  5. A structural check that each servapp has the file layout the Pages
+ *     builder (index.js) and the store require so the deployment does not
+ *     crash: an icon.png and a screenshots/ directory. Missing screenshots/
+ *     (as happened with ROMarr) is a hard error because index.js scans it.
  *
  * Exit code is non-zero if any check fails.
  */
@@ -146,8 +150,31 @@ function checkApp(app) {
     err(app, 'description.json', 'description.json is required for every servapp');
   }
 
+  // ---------- Required store file structure ----------
+  // The Pages builder (index.js) hardcodes these paths for every servapp, so
+  // a missing one breaks the deployment (a missing screenshots/ dir crashes
+  // the build outright, as happened with ROMarr).
+  const iconFile = path.join(base, 'icon.png');
+  if (!fs.existsSync(iconFile)) {
+    err(app, 'icon.png', 'icon.png is required for every servapp (index.js hardcodes it)');
+  }
+
+  const shotsDir = path.join(base, 'screenshots');
+  if (!fs.existsSync(shotsDir) || !fs.lstatSync(shotsDir).isDirectory()) {
+    err(app, 'screenshots/', 'screenshots/ directory is required for every servapp (index.js scans it)');
+  } else {
+    // Warn if screenshots/ contains no real image files (e.g. only a .keep
+    // placeholder) - the app will just render with no screenshots, which is
+    // valid, but is usually a sign one was forgotten.
+    const shots = fs.readdirSync(shotsDir).filter((f) => f !== '.keep' && f !== '.gitkeep');
+    if (shots.length === 0) {
+      warn(app, 'screenshots/', 'screenshots/ has no images (only a placeholder)');
+    }
+  }
+
   // ---------- cosmos-compose.json ----------
   const cfile = path.join(base, 'cosmos-compose.json');
+
   if (fs.existsSync(cfile)) {
     const raw = fs.readFileSync(cfile, 'utf8');
     const trimmed = raw.trim();

--- a/.github/scripts/validate-servapps.js
+++ b/.github/scripts/validate-servapps.js
@@ -85,8 +85,24 @@ const OWN_STORE_BASE = detectOwnStoreBase();
 const errors = [];
 const warnings = [];
 
-function err(app, file, msg) { errors.push('[' + app + '] ' + file + ': ' + msg); }
-function warn(app, file, msg) { warnings.push('[' + app + '] ' + file + ': ' + msg); }
+// Emit a GitHub Actions workflow command annotation (renders as a warning /
+// error callout on the PR / check run) when running under CI. No-op locally.
+// See https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions
+function ghAnnotation(level, app, file, msg) {
+  if (process.env.GITHUB_ACTIONS !== 'true') return;
+  const safe = String(msg).replace(/%/g, '%25').replace(/\r/g, '%0D').replace(/\n/g, '%0A');
+  const relPath = 'servapps/' + app + '/' + file;
+  process.stdout.write(`::${level} file=${relPath}::${safe}\n`);
+}
+
+function err(app, file, msg) {
+  errors.push('[' + app + '] ' + file + ': ' + msg);
+  ghAnnotation('error', app, file, msg);
+}
+function warn(app, file, msg) {
+  warnings.push('[' + app + '] ' + file + ': ' + msg);
+  ghAnnotation('warning', app, file, msg);
+}
 
 function eachApp() {
   const dir = 'servapps';

--- a/.github/scripts/validate-servapps.js
+++ b/.github/scripts/validate-servapps.js
@@ -13,11 +13,12 @@
  *     URLs under THIS repository's own Pages base
  *     (https://<owner>.github.io/<repo>/servapps/...) are treated as
  *     legitimate and not flagged.
- *  4. A structural check that a compose file exists for each servapp.
- *  5. A structural check that each servapp has the file layout the Pages
- *     builder (index.js) and the store require so the deployment does not
- *     crash: an icon.png and a screenshots/ directory. Missing screenshots/
- *     (as happened with ROMarr) is a hard error because index.js scans it.
+ *  4. A structural check that each servapp has the complete required file
+ *     layout so the store renders and the Pages deployment does not crash:
+ *       - description.json
+ *       - cosmos-compose.json (or docker-compose.yml)
+ *       - icon.png
+ *       - screenshots/  (missing this crashes index.js, e.g. ROMarr)
  *
  * Exit code is non-zero if any check fails.
  */
@@ -130,8 +131,57 @@ function checkIconUrl(app, file, url) {
 function checkApp(app) {
   const base = path.join('servapps', app);
 
-  // ---------- description.json ----------
+  // ---------------------------------------------------------------------------
+  // Required store file structure
+  // ---------------------------------------------------------------------------
+  // Every servapp must have the exact layout the Pages builder (index.js) and
+  // the store require. The builder hardcodes these paths for every servapp:
+  //   servapps/<App>/description.json
+  //   servapps/<App>/cosmos-compose.json  (or docker-compose.yml)
+  //   servapps/<App>/icon.png
+  //   servapps/<App>/screenshots/
+  // A missing screenshots/ directory crashes the deploy build outright (as
+  // happened with ROMarr: ENOENT scandir './servapps/ROMarr/screenshots').
+  // All four are required; missing any of them is a hard error.
+  // ---------------------------------------------------------------------------
+
+  // 1) description.json
   const dfile = path.join(base, 'description.json');
+  if (!fs.existsSync(dfile)) {
+    err(app, 'description.json', 'description.json is required for every servapp');
+  }
+
+  // 2) compose file - cosmos-compose.json OR docker-compose.yml
+  const cfile = path.join(base, 'cosmos-compose.json');
+  const yfile = path.join(base, 'docker-compose.yml');
+  if (!fs.existsSync(cfile) && !fs.existsSync(yfile)) {
+    err(app, 'cosmos-compose.json / docker-compose.yml',
+        'a compose file (cosmos-compose.json or docker-compose.yml) is required for every servapp');
+  }
+
+  // 3) icon.png
+  const iconFile = path.join(base, 'icon.png');
+  if (!fs.existsSync(iconFile)) {
+    err(app, 'icon.png', 'icon.png is required for every servapp (index.js hardcodes it)');
+  }
+
+  // 4) screenshots/ directory
+  const shotsDir = path.join(base, 'screenshots');
+  if (!fs.existsSync(shotsDir) || !fs.lstatSync(shotsDir).isDirectory()) {
+    err(app, 'screenshots/', 'screenshots/ directory is required for every servapp (index.js scans it)');
+  } else {
+    // Warn if screenshots/ contains no real image files (e.g. only a .keep
+    // placeholder) - the app will just render with no screenshots, which is
+    // valid, but is usually a sign one was forgotten.
+    const shots = fs.readdirSync(shotsDir).filter((f) => f !== '.keep' && f !== '.gitkeep');
+    if (shots.length === 0) {
+      warn(app, 'screenshots/', 'screenshots/ has no images (only a placeholder)');
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // description.json content validation
+  // ---------------------------------------------------------------------------
   if (fs.existsSync(dfile)) {
     let d = null;
     try { d = JSON.parse(fs.readFileSync(dfile, 'utf8')); }
@@ -146,35 +196,11 @@ function checkApp(app) {
       // NOT validated here - only the store-provided icon URL (and store-hosted artefact files) in the
       // compose file is checked (see checkIconUrl below).
     }
-  } else {
-    err(app, 'description.json', 'description.json is required for every servapp');
   }
 
-  // ---------- Required store file structure ----------
-  // The Pages builder (index.js) hardcodes these paths for every servapp, so
-  // a missing one breaks the deployment (a missing screenshots/ dir crashes
-  // the build outright, as happened with ROMarr).
-  const iconFile = path.join(base, 'icon.png');
-  if (!fs.existsSync(iconFile)) {
-    err(app, 'icon.png', 'icon.png is required for every servapp (index.js hardcodes it)');
-  }
-
-  const shotsDir = path.join(base, 'screenshots');
-  if (!fs.existsSync(shotsDir) || !fs.lstatSync(shotsDir).isDirectory()) {
-    err(app, 'screenshots/', 'screenshots/ directory is required for every servapp (index.js scans it)');
-  } else {
-    // Warn if screenshots/ contains no real image files (e.g. only a .keep
-    // placeholder) - the app will just render with no screenshots, which is
-    // valid, but is usually a sign one was forgotten.
-    const shots = fs.readdirSync(shotsDir).filter((f) => f !== '.keep' && f !== '.gitkeep');
-    if (shots.length === 0) {
-      warn(app, 'screenshots/', 'screenshots/ has no images (only a placeholder)');
-    }
-  }
-
-  // ---------- cosmos-compose.json ----------
-  const cfile = path.join(base, 'cosmos-compose.json');
-
+  // ---------------------------------------------------------------------------
+  // cosmos-compose.json content validation
+  // ---------------------------------------------------------------------------
   if (fs.existsSync(cfile)) {
     const raw = fs.readFileSync(cfile, 'utf8');
     const trimmed = raw.trim();
@@ -223,11 +249,6 @@ function checkApp(app) {
       while ((am = artefactRe.exec(raw)) !== null) {
         checkIconUrl(app, 'cosmos-compose.json', am[0]);
       }
-    }
-  } else {
-    const yfile = path.join(base, 'docker-compose.yml');
-    if (!fs.existsSync(yfile)) {
-      err(app, 'cosmos-compose.json / docker-compose.yml', 'a compose file is required for every servapp');
     }
   }
 }

--- a/.github/scripts/validate-servapps.js
+++ b/.github/scripts/validate-servapps.js
@@ -140,6 +140,55 @@ function checkIconUrl(app, file, url) {
   err(app, file, 'store icon URL is not served by this store (copy-paste?): ' + url);
 }
 
+
+// List the non-mandatory files inside a servapp folder: anything that is not
+// part of the required store structure (description.json, compose file,
+// icon.png) and not under screenshots/. These can carry executable code or
+// structured data, so we flag them with a warning unless they are referenced
+// by the app's cosmos-compose.json (and are not executable).
+function extraFiles(base) {
+  const out = [];
+  if (!fs.existsSync(base)) return out;
+  const walk = (dir, rel) => {
+    let entries;
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch (e) { return; }
+    for (const e of entries) {
+      const r = rel ? rel + '/' + e.name : e.name;
+      if (e.isDirectory()) {
+        // screenshots/ is required + expected; everything else stays fair game
+        if (r === 'screenshots') continue;
+        walk(dir + '/' + e.name, r);
+      } else if (e.isFile()) {
+        const top = r.split('/')[0];
+        if (['description.json', 'cosmos-compose.json', 'docker-compose.yml', 'icon.png'].includes(top)) continue;
+        out.push(r);
+      }
+    }
+  };
+  walk(base, '');
+  return out;
+}
+
+// Is this file referenced (by name or path) inside the compose file text?
+function composeReferences(composeRaw, fileRel) {
+  if (!composeRaw) return false;
+  const needle = fileRel.split('/').pop(); // bare filename
+  return composeRaw.includes(fileRel) || composeRaw.includes(needle);
+}
+
+// Best-effort "executable" detection. On real git checkouts the executable
+// bit is the authoritative signal; when unavailable, we fall back to a
+// conservative extension-based guess for obvious script formats.
+function isExecutableFile(base, rel) {
+  const full = path.join(base, rel);
+  try {
+    const st = fs.statSync(full);
+    if (st.isFile() && (st.mode & 0o111) !== 0) return true;
+  } catch (e) { /* ignore */ }
+  return /\.[a-z0-9]+$/i.test(rel) && /\.[^.]+$/.test(rel) &&
+    /\.(sh|bash|zsh|fish|py|pl|rb|php|js|ts)$/i.test(rel);
+}
+
 // ---------------------------------------------------------------------------
 // Per-app checks
 // ---------------------------------------------------------------------------
@@ -193,6 +242,28 @@ function checkApp(app) {
     if (shots.length === 0) {
       warn(app, 'screenshots/', 'screenshots/ has no images (only a placeholder)');
     }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Non-mandatory files (potential executable / structured data)
+  // ---------------------------------------------------------------------------
+  // Anything in a servapp folder that is NOT part of the required structure
+  // (description.json, compose file, icon.png, screenshots/*) can carry
+  // executable code or structured data. We flag it with a warning so
+  // maintainers review it. Exception: a file that is NOT executable AND is
+  // referenced in the app's cosmos-compose.json is intentionally used by the
+  // app (e.g. an artefacts/config.yaml fetched via wget in post_install) and
+  // does NOT warn.
+  const composeRaw = fs.existsSync(cfile) ? fs.readFileSync(cfile, 'utf8') : '';
+  for (const extra of extraFiles(base)) {
+    const referenced = composeReferences(composeRaw, extra);
+    const executable = isExecutableFile(base, extra);
+    if (!executable && referenced) continue; // intentional, referenced artefact
+    warn(app, extra,
+      'non-mandatory file (not part of the required structure) can contain ' +
+      (executable ? 'executable code' : 'structured data') +
+      (referenced ? '' : ' and is not referenced in cosmos-compose.json') +
+      (executable ? '; review this file' : '; reference it in cosmos-compose.json or remove it'));
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The Pages builder (`index.js`) requires every servapp to have a **specific, complete file structure**: it hardcodes `servapps/<App>/icon.png`, scans `servapps/<App>/screenshots/` for **every** servapp, reads `description.json`, and loads a compose file. A servapp missing its `screenshots/` directory crashes the deploy build outright — exactly what happened in [run 33148363521](https://github.com/azukaar/cosmos-servapps-official/actions/runs/33148363521) with ROMarr (`ENOENT: scandir './servapps/ROMarr/screenshots'`).

## What this PR adds to CI

### 1. Complete required file-structure check
Consolidated into an explicit `Required store file structure` section — every servapp must have:
1. **`description.json`** — required.
2. A **compose file** (`cosmos-compose.json` or `docker-compose.yml`) — required.
3. **`icon.png`** — required (the builder hardcodes this path).
4. **`screenshots/`** directory — required (the builder scans it; missing ⇒ crash).
5. **Warning** (not failure) when `screenshots/` contains no real images (only a `.keep` placeholder).

### 2. Warning on extra (non-mandatory) files
Any file in a servapp folder that is NOT part of the required structure (i.e. not `description.json`, compose file, `icon.png`, or under `screenshots/`) can carry executable code or structured data. Such files now produce a **warning** so maintainers review them.

**Exception:** a file that is **NOT executable** *and* **is referenced in the app's `cosmos-compose.json`** is an intentional store-served artefact (e.g. `FileBrowserQuantum/artefacts/config.yaml`, fetched via `post_install` `wget`) and does **not** warn.
- Referenced = file path or bare filename appears in the compose file.
- Executability = file mode bit, with a conservative extension fallback for obvious script formats (`.sh`, `.py`, …).

### 3. Visible GitHub Actions annotations
Validator warnings/errors are emitted as **workflow-command annotations** (`::warning::` / `::error::` with `file=` pinned to the offending file). Non-fatal warnings show as visible callouts on the PR. Guarded on `GITHUB_ACTIONS` so local runs are unchanged.

## Testing

| Case | Result |
|------|--------|
| Missing `screenshots/`, `icon.png`, `description.json`, both compose files | error, exit 1 |
| Docker-compose-only app | passes |
| `FileBrowserQuantum/artefacts/config.yaml` (referenced, non-exec) | **no warning** (exception) |
| `InfluxDB/artefacts/config.json` (referenced) | no warning |
| `Nightscout/icon_mongo.png` (referenced as icon) | no warning |
| `Piped/artefacts/config.properties` (mentioned in compose) | no warning |
| `mbusd/artefacts/mbusd.conf` (unreferenced, non-exec) | **warning** |
| Executable `scripts/setup.sh` (unreferenced) | **warning** (executable code) |
| Executable + referenced | **warning** (exception only for non-exec) |
| Full repo | 9 pre-existing errors only, warnings: mbusd + unpackerr, **no new errors** |

The branch lives on the `aseracorp/resiSTORE` fork and is based directly on `azukaar/cosmos-servapps-official` master, so it is cleanly mergable (4 commits — `074d38e`, `f61f17e`, `c6a3df8`, `92e4f10` — on top of `c64b3c6`).