### PR TITLE
fix: pin Pages root checkout to master (stop unstable apps leaking onto master store)

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -22,8 +22,15 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      # Always check out master at the root. Without an explicit ref, the
+      # checkout follows the branch that triggered the workflow (GITHUB_REF),
+      # so a push to "unstable" would deploy unstable's apps at the site root
+      # (the master path). Pinning the root to master keeps the two stores
+      # separated: master at "/" and unstable under "/unstable/".
+      - name: Checkout master
         uses: actions/checkout@v7
+        with:
+          ref: master
 
       - name: Checkout unstable
         uses: actions/checkout@v7


### PR DESCRIPTION
## Problem

The **live GitHub Pages site root** (`/index.json`) shows **150 apps** — it's deploying **unstable's** servapps at the master path. The git `master` branch itself is fine (145 apps); the leak comes from the **build/deploy workflow**.

## Root cause

`.github/workflows/static.yml`'s first step checked out the repo with **no `ref`**:

```yaml
- name: Checkout
  uses: actions/checkout@v7
```

`actions/checkout` without an explicit ref follows the branch that **triggered** the workflow (`GITHUB_REF`). The workflow triggers on pushes to both `master` **and** `unstable`. So:

| Triggering push | Root checkout | Result |
|-----------------|---------------|--------|
| `master` | `master` (145 apps) | ✅ correct — root = master, `/unstable/` = unstable |
| `unstable` | `unstable` (150 apps) | ❌ **root built from unstable** → unstable apps deployed at site root |

Confirmed from the actual run logs:
- master-triggered run 33153094936: `Reset branch 'master'` (root = master)
- unstable-triggered run 33153351186: `Switched to a new branch 'unstable'` (root = unstable)

Live verification: `/index.json` = **150 apps** (unstable count), including unstable-only apps (Keeyo, CineDock, LXFamily, LogForge-Unicron, Nora).

## Fix

Pin the root checkout to `master` so the root store is **always** master and unstable is always built under `/unstable/`, regardless of the triggering branch:

```yaml
- name: Checkout master
  uses: actions/checkout@v7
  with:
    ref: master
```

## After merge

The next deploy (from either branch) will publish the **master** 145-app store at `/` and the unstable 150-app store at `/unstable/`, fixing the leaked apps on the master store.

PR branch `fix/pages-deploy` on the `aseracorp/resiSTORE` fork, based on master `7e473f0`.