### PR TITLE
ci: validate repository/image URLs and image architecture coverage

### DIFF
--- a/.github/scripts/validate-servapps.js
+++ b/.github/scripts/validate-servapps.js
@@ -308,8 +308,9 @@ function parseImageRef(str) {
         return { registry: 'registry-1.docker.io', repository: name, tag: 'latest' };
       }
       // github pkgs page: github.com/owner/repo/pkgs/container/name
+      // The ghcr image is <owner>/<package> (package is usually the repo name).
       if (host === 'github.com' && p.includes('/pkgs/container/')) {
-        const m = p.match(/^([^/]+\/[^/]+)\/pkgs\/container\/([^/]+)/);
+        const m = p.match(/^([^/]+)\/[^/]+\/pkgs\/container\/([^/]+)/);
         if (m) {
           return { registry: 'ghcr.io', repository: m[1].toLowerCase() + '/' + m[2].toLowerCase(), tag: 'latest' };
         }
@@ -503,6 +504,125 @@ async function checkRepositoryAndImage(app, d) {
   }
 }
 
+
+// ---------------------------------------------------------------------------
+// Compose services[*].image validation + description/compose image cross-check
+// ---------------------------------------------------------------------------
+
+// Normalize an image reference to a comparable {repo, tag} for the
+// description-vs-compose cross-check. Docker Hub and linuxserver's mirror
+// (lscr.io) are folded together; tag defaults to "latest".
+function imageIdentity(str) {
+  const p = parseImageRef(str);
+  if (!p) return null;
+  let registry = p.registry;
+  let repo = p.repository.replace(/\/$/, '');
+  // fold docker hub registries + lscr.io (linuxserver's dockerhub mirror)
+  if (['registry-1.docker.io', 'docker.io', 'index.docker.io'].includes(registry)) registry = 'docker.io';
+  if (registry === 'lscr.io') registry = 'docker.io';
+  let tag = (p.tag || 'latest').toLowerCase();
+  return { registry, repo: repo.toLowerCase(), tag };
+}
+
+function imagesMatch(a, b) {
+  if (!a || !b) return false;
+  if (a.registry !== b.registry) return false;
+  // repository must agree (ignore a trailing ":tag" mismatch caused by
+  // docker.io official images vs the slash form)
+  const aRepo = a.repo.replace(/^library\//, '');
+  const bRepo = b.repo.replace(/^library\//, '');
+  if (aRepo !== bRepo) return false;
+  // tag comparison: latest/tag is acceptable against any specific tag, and
+  // a missing tag (default latest) against any tag
+  if (a.tag === 'latest' || b.tag === 'latest') return true;
+  return a.tag === b.tag;
+}
+
+// Extract {name,image}[] for every service in a rendered compose document.
+// Handles both the JSON object form (cosmos-compose.json) and a plain
+// docker-compose.yml YAML doc (regex-based, best effort).
+function composeServiceImages(rendered, isYaml) {
+  const out = [];
+  if (!rendered) return out;
+  if (isYaml) {
+    // minimal YAML: look for "    <name>:" under a "services:" block followed
+    // by an "image:" line. Handles the common indentation.
+    const rx = /(?:^|\n)\s{2}(\S[^:]*):\s*(?:\n|$)([\s\S]*?)(?=\n\s,{1,2}\S|\n\s{0,2}\w)/g;
+    // Simpler: split services block
+    const servicesBlock = rendered.match(/(?:^|\n)services:\s*\n([\s\S]*)/);
+    if (servicesBlock) {
+      const block = servicesBlock[1];
+      const lines = block.split('\n');
+      let curName = null;
+      for (const line of lines) {
+        const svc = line.match(/^(\s{2,4})?([A-Za-z0-9_.-]+):\s*$/);
+        const img = line.match(/image:\s*['"]?([^\s'"]+)['"]?\s*$/);
+        if (svc && !line.startsWith('    ')) { curName = svc[2]; }
+        else if (img && curName) { out.push({ name: curName, image: img[1] }); }
+      }
+    }
+    return out;
+  }
+  // JSON form: rendered is a parsed object (we parse before calling) OR string
+  let doc = rendered;
+  if (typeof rendered === 'string') { try { doc = JSON.parse(rendered); } catch (e) { return out; } }
+  const services = doc && doc.services;
+  if (services && typeof services === 'object') {
+    for (const [name, conf] of Object.entries(services)) {
+      if (conf && typeof conf === 'object' && conf.image) {
+        out.push({ name, image: String(conf.image) });
+      }
+    }
+  }
+  return out;
+}
+
+// Check every compose service image is a valid, existing docker image and
+// that description.image matches the primary service ({ServiceName}) image.
+async function checkComposeImages(app, rendered, isYaml, composeFileLabel) {
+  const services = composeServiceImages(rendered, isYaml);
+  if (!services.length) return;
+
+  // primary service is the one named {ServiceName} -> after render, matches
+  // the value used in the render context ("TestSvc"); if present, the service
+  // key equals TestSvc, otherwise fall back to the first service.
+  let primary = services.find((s) => s.name === 'TestSvc') || services[0];
+
+  // ---- 1) each service image must be a valid docker image ----
+  // Dedupe image refs within an app to limit registry calls.
+  const seen = new Set();
+  for (const svc of services) {
+    if (!svc.image) { err(app, composeFileLabel, 'services.' + svc.name + '.image is missing'); continue; }
+    const ref = parseImageRef(svc.image);
+    if (!ref) { err(app, composeFileLabel, 'services.' + svc.name + '.image is not a valid docker image reference: ' + svc.image); continue; }
+    const key = (ref.registry || '') + '/' + ref.repository + ':' + (ref.tag || 'latest');
+    if (seen.has(key)) continue;
+    seen.add(key);
+    const archs = await imageArchs(svc.image); // reuse: 404 => not found
+    if (archs.status === 'not-found') {
+      err(app, composeFileLabel, 'services.' + svc.name + '.image does not exist (registry 404): ' + svc.image);
+    }
+    // non-404 / non-ok statuses (network etc.) are ignored here; the primary
+    // existence/arch check is authoritative.
+  }
+
+  // ---- cross-check description.image vs primary service image ----
+  const dfile = path.join('servapps', app, 'description.json');
+  if (primary && fs.existsSync(dfile)) {
+    let desc = null;
+    try { desc = JSON.parse(fs.readFileSync(dfile, 'utf8')); } catch (e) {}
+    if (desc && desc.image) {
+      const compId = imageIdentity(primary.image);
+      const descId = imageIdentity(desc.image);
+      if (compId && descId && !imagesMatch(compId, descId)) {
+        warn(app, composeFileLabel,
+          'description.image (' + desc.image + ') does not match the primary service image (' +
+          primary.image + ') in services.' + primary.name + '.image');
+      }
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Per-app checks
 // ---------------------------------------------------------------------------
@@ -643,7 +763,10 @@ async function checkApp(app) {
           err(app, 'cosmos-compose.json', 'rendered output is not valid JSON: ' + String(e.message).split('\n')[0]);
         }
       }
-      // Only store-served icon URLs and store-hosted artefact URLs are validated against the whitelist; every
+      // Validate every services.*.image in the rendered compose and cross-check
+      // description.image against the primary ({ServiceName}) service image.
+      await checkComposeImages(app, rendered, !isJson, cfile.split('/').pop());
+      // Only store-served icon URLs and store-hosted artifact URLs are referenced against the whitelist; every
       // other URL in the compose file (homepages, config defaults, app 3rd
       // -party sources) is intentionally skipped.
       // 1) cosmos-icon references.

--- a/.github/scripts/validate-servapps.js
+++ b/.github/scripts/validate-servapps.js
@@ -189,11 +189,325 @@ function isExecutableFile(base, rel) {
     /\.(sh|bash|zsh|fish|py|pl|rb|php|js|ts)$/i.test(rel);
 }
 
+
+// Network / registry helpers (Node 18+ global fetch with timeout)
+// ---------------------------------------------------------------------------
+
+const NET_TIMEOUT = 15000;
+
+async function getJSON(url, headers) {
+  const ctl = new AbortController();
+  const t = setTimeout(() => ctl.abort(), NET_TIMEOUT);
+  try {
+    const res = await fetch(url, { headers: headers || {}, signal: ctl.signal, redirect: 'follow' });
+    const text = await res.text();
+    let json = null;
+    try { json = JSON.parse(text); } catch (e) { /* not json */ }
+    return { status: res.status, ok: res.ok, json, text };
+  } catch (e) {
+    return { error: e.name === 'AbortError' ? 'timeout' : String(e && e.message || e) };
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+async function getStatus(url, headers) {
+  const ctl = new AbortController();
+  const t = setTimeout(() => ctl.abort(), NET_TIMEOUT);
+  try {
+    const res = await fetch(url, { headers: headers || {}, signal: ctl.signal, redirect: 'follow', method: 'HEAD' });
+    // Some hosts reject HEAD; fall back to GET if needed
+    if (res.status >= 400 || res.status === 405) {
+      const res2 = await fetch(url, { headers: headers || {}, signal: ctl.signal, redirect: 'follow', method: 'GET' });
+      return { status: res2.status, ok: res2.ok, url: res2.url };
+    }
+    return { status: res.status, ok: res.ok, url: res.url };
+  } catch (e) {
+    return { error: e.name === 'AbortError' ? 'timeout' : String(e && e.message || e) };
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+// Normalize a description.json supported_architectures entry to a canonical
+// set. The field is quite free-form across the store; we map the common
+// spellings onto the architecture names the registries use.
+function canonicalArchs(list) {
+  const map = {
+    'amd64': 'amd64', 'x86': 'amd64', 'x86_64': 'amd64', 'x64': 'amd64',
+    '386': '386', 'i386': '386', 'i686': '386', 'x86-32': '386',
+    'arm64': 'arm64', 'arm64v8': 'arm64', 'aarch64': 'arm64', 'arm64/v8': 'arm64', 'armv8': 'arm64', 'arm64_64': 'arm64',
+    'arm': 'arm/v7', 'armv7': 'arm/v7', 'arm7': 'arm/v7', 'arm32v7': 'arm/v7', 'arm/v7': 'arm/v7', 'armhf': 'arm/v7',
+    'armv6': 'arm/v6', 'arm32v6': 'arm/v6', 'arm/v6': 'arm/v6',
+    'armv5': 'arm/v5', 'arm32v5': 'arm/v5', 'arm/v5': 'arm/v5',
+    'ppc64le': 'ppc64le', 's390x': 's390x', 'riscv64': 'riscv64', 'mips64le': 'mips64le',
+    'arm/v8': 'arm/v7', // typo found in the store; arm32v7 releases are tagged arm/v8 incorrectly
+    'arm64v7': 'arm/v7',
+  };
+  if (!Array.isArray(list)) return [];
+  const out = new Set();
+  for (const raw of list) {
+    // entries can themselves be comma- or space-separated lists, e.g.
+    // ["arm64, amd64"] - split them into individual arch names
+    const parts = String(raw).split(/[,;\s]+/).filter(Boolean);
+    for (const a of parts) {
+      const k = a.toLowerCase().replace(/^linux\//, '').replace(/^linux_/, '');
+      const canon = map[k] || k;
+      out.add(canon);
+    }
+  }
+  return out;
+}
+
+// Convert the image tag API / manifest arch+variant to a canonical arch.
+function imageArchToCanonical(arch, variant) {
+  const a = String(arch || '').toLowerCase();
+  if (a === 'arm') {
+    // generic arm -> use variant if present
+    if (variant === 'v6') return 'arm/v6';
+    if (variant === 'v5') return 'arm/v5';
+    return 'arm/v7';
+  }
+  if (a === 'arm64') return 'arm64';
+  if (a === 'amd64') return 'amd64';
+  if (a === '386') return '386';
+  if (a === 'ppc64le') return 'ppc64le';
+  if (a === 's390x') return 's390x';
+  if (a === 'riscv64') return 'riscv64';
+  if (a === 'mips64le') return 'mips64le';
+  if (a === 'unknown' || !a) return null;
+  return a;
+}
+
+// Hosts we accept as docker image registries / package registries.
+const KNOWN_REGISTRIES = new Set([
+  'docker.io', 'registry-1.docker.io', 'hub.docker.com', 'index.docker.io',
+  'ghcr.io', 'lscr.io', 'quay.io', 'codeberg.org', 'docker.n8n.io',
+  'docker.io.n8n', 'ghcr', 'gcr.io', 'k8s.gcr.io', 'registry.gitlab.com',
+  'ecr.public', 'public.ecr.aws', 'docker.io.linuxserver', 'n8nio',
+]);
+
+function parseImageRef(str) {
+  // Parse a docker image reference (without registry) or a registry URL into
+  // { registry, repository, tag }.
+  let s = String(str || '').trim();
+  if (!s) return null;
+  if (s.startsWith('http://') || s.startsWith('https://')) {
+    try {
+      const u = new URL(s);
+      const host = u.hostname;
+      let p = u.pathname.replace(/^\/+/, '');
+      // docker hub page: hub.docker.com/r/ns/repo
+      if (host === 'hub.docker.com' && p.startsWith('r/')) {
+        p = p.slice(2).replace(/\/$/, '');
+        return parseImageRef(p);
+      }
+      // docker hub official image page: hub.docker.com/_/name
+      if (host === 'hub.docker.com' && p.startsWith('_/')) {
+        const name = p.slice(2).replace(/\/$/, '');
+        return { registry: 'registry-1.docker.io', repository: name, tag: 'latest' };
+      }
+      // github pkgs page: github.com/owner/repo/pkgs/container/name
+      if (host === 'github.com' && p.includes('/pkgs/container/')) {
+        const m = p.match(/^([^/]+\/[^/]+)\/pkgs\/container\/([^/]+)/);
+        if (m) {
+          return { registry: 'ghcr.io', repository: m[1].toLowerCase() + '/' + m[2].toLowerCase(), tag: 'latest' };
+        }
+      }
+      // codeberg package page: codeberg.org/owner/-/packages/container/name
+      if (host === 'codeberg.org') {
+        const m = p.match(/^([^/]+)\/-\/packages\/container\/([^/]+)/);
+        if (m) {
+          return { registry: 'codeberg.org', repository: m[1] + '/' + m[2], tag: 'latest' };
+        }
+      }
+      // ghcr.io mirror (path may carry an optional :tag)
+      if (host.endsWith('ghcr.io')) {
+        let repo = p.replace(/\/$/, '');
+        let tag = 'latest';
+        const slash = repo.lastIndexOf('/');
+        const colon = repo.lastIndexOf(':');
+        if (colon > slash) { tag = repo.slice(colon + 1); repo = repo.slice(0, colon); }
+        return { registry: host, repository: repo, tag };
+      }
+      // generic registry URL: <host>/<ns>/<name>[:tag] - only for known hosts
+      if (KNOWN_REGISTRIES.has(host) && p.includes('/')) {
+        const parts = p.split('/');
+        const last = parts.pop();
+        let tag = 'latest';
+        let repoName = last;
+        if (last.includes(':')) { const sp = last.split(':'); repoName = sp[0]; tag = sp[1]; }
+        parts.push(repoName);
+        return { registry: host, repository: parts.join('/'), tag };
+      }
+      // unknown host + unknown page => not a docker image reference at all
+      return null;
+    } catch (e) { return null; }
+  }
+  // strip tag
+  let repo = s;
+  let tag = 'latest';
+  if (s.includes('@')) { s = s.split('@')[0]; }
+  if (s.includes(':')) {
+    // careful: registry:port vs tag. Treat last colon as tag if after last slash
+    const slash = s.lastIndexOf('/');
+    const colon = s.lastIndexOf(':');
+    if (colon > slash) { repo = s.slice(0, colon); tag = s.slice(colon + 1); }
+    else repo = s;
+  }
+  const parts = repo.split('/');
+  // registries
+  if (parts.length >= 3 && parts[0].includes('.') && parts[0] !== 'registry-1.docker.io') {
+    return { registry: parts[0], repository: parts.slice(1).join('/'), tag };
+  }
+  // docker.io / docker hub default
+  return { registry: 'registry-1.docker.io', repository: repo, tag };
+}
+
+function imageDisplay(str) {
+  const p = parseImageRef(str);
+  if (!p) return String(str);
+  return (p.registry && p.registry !== 'registry-1.docker.io' ? p.registry + '/' : '') + p.repository + ':' + p.tag;
+}
+
+// Get the set of architectures an image manifest publishes. Returns a Promise
+// that resolves to { archs:Set|null, status } - archs=null means we could not
+// determine them (caller decides how to treat).
+async function imageArchs(imageUrl) {
+  const ref = parseImageRef(imageUrl);
+  if (!ref) return { archs: null, status: 'unparseable' };
+  const reg = ref.registry;
+  const repo = ref.repository;
+  const tag = ref.tag || 'latest';
+
+  // --- Docker Hub: use the public tag API (reliable, no token needed) ---
+  if (reg === 'registry-1.docker.io') {
+    // official (library) images have no namespace in the ref but live under
+    // "library/" in the Docker Hub API
+    const apiRepo = (repo.indexOf('/') === -1) ? 'library/' + repo : repo;
+    const api = 'https://hub.docker.com/v2/repositories/' + apiRepo + '/tags/' + tag;
+    const r = await getJSON(api);
+    if (r.error) return { archs: null, status: r.error };
+    if (r.status === 404) return { archs: null, status: 'not-found' };
+    if (r.status !== 200 || !r.json) return { archs: null, status: 'http-' + r.status };
+    const set = new Set();
+    for (const img of (r.json.images || [])) {
+      if (img.os && img.os !== 'linux') continue;
+      const c = imageArchToCanonical(img.architecture, img.variant);
+      if (c) set.add(c);
+    }
+    return { archs: set, status: 'ok' };
+  }
+
+  // --- OCI registry (ghcr.io and friends): manifest index ---
+  try {
+    const headers = { 'Accept': 'application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json' };
+    let url = 'https://' + reg + '/v2/' + repo + '/manifests/' + tag;
+    // anonymous token flow
+    if (reg === 'ghcr.io') {
+      const tok = await getJSON('https://ghcr.io/token?scope=repository:' + repo + ':pull');
+      if (!tok.error && tok.json && tok.json.token) {
+        headers.Authorization = 'Bearer ' + tok.json.token;
+      }
+    }
+    const m = await getJSON(url, headers);
+    if (m.error) return { archs: null, status: 'net-' + m.error };
+    if (m.status === 404 || m.status === 401 && m.text.includes('not found')) return { archs: null, status: 'not-found' };
+    if (m.status !== 200 || !m.json) return { archs: null, status: 'http-' + m.status };
+    const set = new Set();
+    if (m.json.manifests) {
+      for (const mm of m.json.manifests) {
+        const p = mm.platform || {};
+        if (p.os && p.os !== 'linux') continue;
+        const c = imageArchToCanonical(p.architecture || (mm.artifactType ? null : p.architecture), p.variant);
+        if (c) set.add(c);
+      }
+      return { archs: set, status: 'ok' };
+    }
+    // single-arch manifest: no platform list
+    return { archs: set, status: 'single' };
+  } catch (e) {
+    return { archs: null, status: 'net-exc' };
+  }
+}
+
+// Check description.json repository + image fields live against their sources.
+async function checkRepositoryAndImage(app, d) {
+  // ------------------------- repository URL -------------------------
+  const repo = d.repository;
+  if (repo) {
+    const st = await getStatus(repo);
+    if (st.error) {
+      warn(app, 'description.json', 'repository URL could not be checked (' + st.error + '): ' + repo);
+    } else if (st.status >= 400) {
+      err(app, 'description.json', 'repository URL returned HTTP ' + st.status + ': ' + repo);
+    } else {
+      // For GitHub URLs, it must be a real repository (owner/repo), otherwise warn.
+      try {
+        const u = new URL(repo);
+        if (u.hostname === 'github.com' || u.hostname === 'www.github.com') {
+          const parts = u.pathname.split('/').filter(Boolean);
+          if (parts.length < 2) {
+            warn(app, 'description.json', 'repository is not a repository: ' + repo + ' (should be https://github.com/<owner>/<repo>)');
+          } else if (parts[0].length && parts[1].length && parts.length >= 2) {
+            // verify via GitHub API: a repo returns 200, a user/org or bad path returns 404
+            const api = await getStatus('https://api.github.com/repos/' + parts[0] + '/' + parts[1], { 'Accept': 'application/vnd.github+json', 'User-Agent': 'cosmos-ci-validator' });
+            if (api.status === 404) {
+              warn(app, 'description.json', 'repository is not a repository: ' + repo + ' (GitHub reports 404 for ' + parts[0] + '/' + parts[1] + ')');
+            }
+          }
+        }
+      } catch (e) { /* not a URL we can parse */ }
+    }
+  }
+
+  // ------------------------- image URL -------------------------
+  const image = d.image;
+  if (image) {
+    const ref = parseImageRef(image);
+    if (!ref) {
+      err(app, 'description.json', 'image is not a valid docker image reference: ' + image);
+      return;
+    }
+    const archs = await imageArchs(image);
+    if (archs.status === 'not-found') {
+      err(app, 'description.json', 'image does not exist (registry 404): ' + imageDisplay(image));
+      return;
+    }
+    if (archs.status === 'unparseable') {
+      err(app, 'description.json', 'image is not a valid docker image reference: ' + image);
+      return;
+    }
+    if (archs.status === 'ok' && archs.archs && archs.archs.size) {
+      // ------------------------- arch comparison -------------------------
+      const announced = canonicalArchs(d.supported_architectures);
+      const imageSet = archs.archs;
+      // error: announced archs missing in the image
+      for (const a of announced) {
+        if (!imageSet.has(a)) {
+          err(app, 'description.json',
+            'announced architecture ' + a + ' is not provided by image ' + imageDisplay(image) + ' (image provides: ' + Array.from(imageSet).sort().join(', ') + ')');
+        }
+      }
+      // warning: image archs not announced
+      for (const a of imageSet) {
+        if (!announced.has(a)) {
+          warn(app, 'description.json',
+            'image ' + imageDisplay(image) + ' provides architecture ' + a + ' which is not announced in supported_architectures');
+        }
+      }
+    }
+    // If archs could not be determined (network/registry edge), we do NOT
+    // hard-fail the arch comparison - only the image existence check above
+    // (404 -> error) is authoritative.
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Per-app checks
 // ---------------------------------------------------------------------------
 
-function checkApp(app) {
+async function checkApp(app) {
   const base = path.join('servapps', app);
 
   // ---------------------------------------------------------------------------
@@ -286,6 +600,15 @@ function checkApp(app) {
   }
 
   // ---------------------------------------------------------------------------
+  // description.json repository / image URL + architecture checks
+  // ---------------------------------------------------------------------------
+  if (fs.existsSync(dfile)) {
+    let dd = null;
+    try { dd = JSON.parse(fs.readFileSync(dfile, 'utf8')); } catch (e) { /* already reported */ }
+    if (dd) await checkRepositoryAndImage(app, dd);
+  }
+
+  // ---------------------------------------------------------------------------
   // cosmos-compose.json content validation
   // ---------------------------------------------------------------------------
   if (fs.existsSync(cfile)) {
@@ -346,16 +669,23 @@ function checkApp(app) {
 
 const only = process.argv[2];
 const apps = only ? [only] : eachApp();
-apps.forEach(checkApp);
 
-const hasErr = errors.length > 0;
-if (warnings.length) {
-  console.log('\n' + warnings.length + ' warning(s):');
-  warnings.forEach((w) => console.log('  [warn] ' + w));
-}
-if (errors.length) {
-  console.log('\n' + errors.length + ' error(s):');
-  errors.forEach((e) => console.log('  [error] ' + e));
-}
-console.log('\nChecked ' + apps.length + ' app(s).');
-process.exit(hasErr ? 1 : 0);
+(async () => {
+  // run app checks sequentially to avoid hammering the registries with parallel
+  // requests from 145 apps at once
+  for (const app of apps) {
+    await checkApp(app);
+  }
+
+  const hasErr = errors.length > 0;
+  if (warnings.length) {
+    console.log('\n' + warnings.length + ' warning(s):');
+    warnings.forEach((w) => console.log('  [warn] ' + w));
+  }
+  if (errors.length) {
+    console.log('\n' + errors.length + ' error(s):');
+    errors.forEach((e) => console.log('  [error] ' + e));
+  }
+  console.log('\nChecked ' + apps.length + ' app(s).');
+  process.exit(hasErr ? 1 : 0);
+})();

--- a/.github/scripts/validate-servapps.js
+++ b/.github/scripts/validate-servapps.js
@@ -628,14 +628,14 @@ async function checkComposeImages(app, rendered, isYaml, composeFileLabel) {
 // Schema checks - mandatory / optional / allowed fields for description.json
 // and the compose files.
 //
-// The mandatory and known field sets are derived from the fields actually used
-// by the apps in this repository (description.json is 100% consistent; the
-// compose top level is services + cosmos-installer + minVersion, service level
-// is image + container_name + labels, both universal across all services).
-//
-// Optional fields are a curated list of the fields that appear in at least one
-// existing app. Any other field (never seen in the store) is rejected as
-// undocumented.
+// Mandatory fields are derived from the fields present in (essentially) every
+// existing app. The allowed (optional) field vocabulary is the set of fields
+// Cosmos-Server actually supports when creating a service (the struct in
+// src/docker/api_blueprint.go: ContainerCreateRequestContainer and
+// DockerServiceCreateRequest), plus a few fields existing apps legitimately
+// use. Matching is case-insensitive because Go's encoding/json accepts struct
+// fields by name regardless of the case of the compose keys. A field that is
+// not in the supported vocabulary is rejected as undocumented.
 // ---------------------------------------------------------------------------
 
 const DESC_MANDATORY = [
@@ -651,15 +651,34 @@ const COMPOSE_TOP_OPTIONAL = ['networks', 'version', 'volumes'];
 const COMPOSE_TOP_KNOWN = new Set([...COMPOSE_TOP_MANDATORY, ...COMPOSE_TOP_OPTIONAL]);
 
 const COMPOSE_SERVICE_MANDATORY = ['image', 'container_name', 'labels'];
+
+// Canonical service fields supported by Cosmos-Server (json tags of
+// ContainerCreateRequestContainer in src/docker/api_blueprint.go) plus fields
+// already used by existing apps that Cosmos's types do not (yet) declare.
 const COMPOSE_SERVICE_OPTIONAL = [
-  'environment', 'volumes', 'restart', 'routes', 'UID', 'GID', 'user', 'depends_on',
-  'ports', 'expose', 'command', 'entrypoint', 'healthcheck', 'networks', 'cap_add',
-  'cap_drop', 'devices', 'device', 'extra_hosts', 'hostname', 'init', 'links',
-  'logging', 'network_mode', 'post_install', 'privileged', 'read_only',
-  'security_opt', 'shm_size', 'stdin_open', 'stop_grace_period', 'tmpfs', 'tty',
-  'working_dir', 'group_add', 'deploy'
+  // Cosmos-Server ContainerCreateRequestContainer fields
+  'environment', 'labels', 'ports', 'volumes', 'networks', 'routes', 'links',
+  'restart', 'devices', 'expose', 'depends_on', 'tty', 'stdin_open', 'command',
+  'entrypoint', 'runtime', 'working_dir', 'user', 'uid', 'gid', 'hostname',
+  'domainname', 'mac_address', 'privileged', 'network_mode', 'stop_signal',
+  'stop_grace_period', 'healthcheck', 'dns', 'dns_search', 'extra_hosts',
+  'security_opt', 'storage_opt', 'sysctls', 'isolation', 'cap_add', 'cap_drop',
+  'mem_limit', 'mem_reservation', 'cpus', 'cpu_shares', 'cpuset_cpus',
+  'post_install',
+  // fields used by existing apps but not (yet) in Cosmos-Server's struct
+  'init', 'logging', 'shm_size', 'group_add', 'deploy'
 ];
-const COMPOSE_SERVICE_KNOWN = new Set([...COMPOSE_SERVICE_MANDATORY, ...COMPOSE_SERVICE_OPTIONAL]);
+
+// Normalize a field name for case-insensitive, separator-insensitive matching
+// (Go's encoding/json matches struct fields case-insensitively, so compose keys
+// like CapAdd / cap_add / CAPADD are all honored).
+function normalizeFieldKey(k) {
+  return String(k || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+const COMPOSE_SERVICE_SUPPORTED = new Map();
+for (const f of COMPOSE_SERVICE_OPTIONAL) COMPOSE_SERVICE_SUPPORTED.set(normalizeFieldKey(f), f);
+for (const f of COMPOSE_SERVICE_MANDATORY) COMPOSE_SERVICE_SUPPORTED.set(normalizeFieldKey(f), f);
 
 function checkMissing(app, file, which, present) {
   for (const f of [...which].sort()) {
@@ -704,9 +723,17 @@ function checkComposeSchema(app, rendered, isYaml, composeFileLabel) {
       for (const f of COMPOSE_SERVICE_MANDATORY) {
         if (!keys.has(f)) err(app, composeFileLabel, prefix + ': missing mandatory field "' + f + '"');
       }
-      // report undocumented per-service fields
+      // report unsupported per-service fields (case-insensitive against the
+      // Cosmos-Server supported vocabulary)
+      const ACCEPTED_CASINGS = new Set(['UID', 'GID']); // long-standing store convention
       for (const k of Object.keys(conf)) {
-        if (!COMPOSE_SERVICE_KNOWN.has(k)) err(app, composeFileLabel, prefix + ': field "' + k + '" is not documented (not present in any existing app)');
+        const nk = normalizeFieldKey(k);
+        const canonical = COMPOSE_SERVICE_SUPPORTED.get(nk);
+        if (!canonical) {
+          err(app, composeFileLabel, prefix + ': field "' + k + '" is not supported by Cosmos-Server (not in the supported compose vocabulary)');
+        } else if (!ACCEPTED_CASINGS.has(k) && canonical !== k) {
+          warn(app, composeFileLabel, prefix + ': field "' + k + '" should be spelled "' + canonical + '" (canonical Cosmos field name)');
+        }
       }
     }
   }

--- a/.github/scripts/validate-servapps.js
+++ b/.github/scripts/validate-servapps.js
@@ -623,6 +623,94 @@ async function checkComposeImages(app, rendered, isYaml, composeFileLabel) {
   }
 }
 
+
+// ---------------------------------------------------------------------------
+// Schema checks - mandatory / optional / allowed fields for description.json
+// and the compose files.
+//
+// The mandatory and known field sets are derived from the fields actually used
+// by the apps in this repository (description.json is 100% consistent; the
+// compose top level is services + cosmos-installer + minVersion, service level
+// is image + container_name + labels, both universal across all services).
+//
+// Optional fields are a curated list of the fields that appear in at least one
+// existing app. Any other field (never seen in the store) is rejected as
+// undocumented.
+// ---------------------------------------------------------------------------
+
+const DESC_MANDATORY = [
+  'name', 'description', 'longDescription', 'repository', 'image', 'tags', 'supported_architectures'
+];
+const DESC_OPTIONAL = ['translation'];
+// Known = mandatory + optional (the full documented vocabulary). Any key
+// outside this set has never been seen in an existing app and is rejected.
+const DESC_KNOWN = new Set([...DESC_MANDATORY, ...DESC_OPTIONAL]);
+
+const COMPOSE_TOP_MANDATORY = ['services', 'cosmos-installer', 'minVersion'];
+const COMPOSE_TOP_OPTIONAL = ['networks', 'version', 'volumes'];
+const COMPOSE_TOP_KNOWN = new Set([...COMPOSE_TOP_MANDATORY, ...COMPOSE_TOP_OPTIONAL]);
+
+const COMPOSE_SERVICE_MANDATORY = ['image', 'container_name', 'labels'];
+const COMPOSE_SERVICE_OPTIONAL = [
+  'environment', 'volumes', 'restart', 'routes', 'UID', 'GID', 'user', 'depends_on',
+  'ports', 'expose', 'command', 'entrypoint', 'healthcheck', 'networks', 'cap_add',
+  'cap_drop', 'devices', 'device', 'extra_hosts', 'hostname', 'init', 'links',
+  'logging', 'network_mode', 'post_install', 'privileged', 'read_only',
+  'security_opt', 'shm_size', 'stdin_open', 'stop_grace_period', 'tmpfs', 'tty',
+  'working_dir', 'group_add', 'deploy'
+];
+const COMPOSE_SERVICE_KNOWN = new Set([...COMPOSE_SERVICE_MANDATORY, ...COMPOSE_SERVICE_OPTIONAL]);
+
+function checkMissing(app, file, which, present) {
+  for (const f of [...which].sort()) {
+    if (!present.has(f)) err(app, file, 'missing mandatory field "' + f + '"');
+  }
+}
+
+function checkUndocumented(app, file, which, keys) {
+  for (const k of keys) {
+    if (!which.has(k)) err(app, file, 'field "' + k + '" is not documented (not present in any existing app)');
+  }
+}
+
+// description.json top-level schema
+function checkDescriptionSchema(app, d) {
+  if (!d || typeof d !== 'object') return;
+  const keys = new Set(Object.keys(d));
+  checkMissing(app, 'description.json', DESC_MANDATORY, keys);
+  checkUndocumented(app, 'description.json', DESC_KNOWN, Object.keys(d));
+}
+
+// cosmos-compose.json / docker-compose.yml schema.
+// rendered = the whiskers-rendered compose object (JSON form) or raw string for YAML.
+function checkComposeSchema(app, rendered, isYaml, composeFileLabel) {
+  let doc = rendered;
+  if (typeof doc === 'string') {
+    try { doc = JSON.parse(doc); } catch (e) { return; }
+  }
+  if (!doc || typeof doc !== 'object') return;
+
+  const topKeys = new Set(Object.keys(doc));
+  checkMissing(app, composeFileLabel, COMPOSE_TOP_MANDATORY, topKeys);
+  checkUndocumented(app, composeFileLabel, COMPOSE_TOP_KNOWN, Object.keys(doc));
+
+  const services = doc.services;
+  if (services && typeof services === 'object') {
+    for (const [name, conf] of Object.entries(services)) {
+      if (!conf || typeof conf !== 'object') continue;
+      const prefix = 'services.' + name;
+      const keys = new Set(Object.keys(conf));
+      // report missing mandatory per-service fields
+      for (const f of COMPOSE_SERVICE_MANDATORY) {
+        if (!keys.has(f)) err(app, composeFileLabel, prefix + ': missing mandatory field "' + f + '"');
+      }
+      // report undocumented per-service fields
+      for (const k of Object.keys(conf)) {
+        if (!COMPOSE_SERVICE_KNOWN.has(k)) err(app, composeFileLabel, prefix + ': field "' + k + '" is not documented (not present in any existing app)');
+      }
+    }
+  }
+}
 // ---------------------------------------------------------------------------
 // Per-app checks
 // ---------------------------------------------------------------------------
@@ -725,7 +813,10 @@ async function checkApp(app) {
   if (fs.existsSync(dfile)) {
     let dd = null;
     try { dd = JSON.parse(fs.readFileSync(dfile, 'utf8')); } catch (e) { /* already reported */ }
-    if (dd) await checkRepositoryAndImage(app, dd);
+    if (dd) {
+      await checkRepositoryAndImage(app, dd);
+      checkDescriptionSchema(app, dd);
+    }
   }
 
   // ---------------------------------------------------------------------------
@@ -766,6 +857,7 @@ async function checkApp(app) {
       // Validate every services.*.image in the rendered compose and cross-check
       // description.image against the primary ({ServiceName}) service image.
       await checkComposeImages(app, rendered, !isJson, cfile.split('/').pop());
+      checkComposeSchema(app, rendered, !isJson, cfile.split('/').pop());
       // Only store-served icon URLs and store-hosted artifact URLs are referenced against the whitelist; every
       // other URL in the compose file (homepages, config defaults, app 3rd
       // -party sources) is intentionally skipped.

--- a/.github/scripts/validate-servapps.js
+++ b/.github/scripts/validate-servapps.js
@@ -724,14 +724,15 @@ function checkComposeSchema(app, rendered, isYaml, composeFileLabel) {
         if (!keys.has(f)) err(app, composeFileLabel, prefix + ': missing mandatory field "' + f + '"');
       }
       // report unsupported per-service fields (case-insensitive against the
-      // Cosmos-Server supported vocabulary)
-      const ACCEPTED_CASINGS = new Set(['UID', 'GID']); // long-standing store convention
+      // Cosmos-Server supported vocabulary). Non-canonical casing is always
+      // flagged as a warning - Cosmos's encoding/json binds by field name
+      // regardless of case, but the store's canonical spelling is lowercase.
       for (const k of Object.keys(conf)) {
         const nk = normalizeFieldKey(k);
         const canonical = COMPOSE_SERVICE_SUPPORTED.get(nk);
         if (!canonical) {
           err(app, composeFileLabel, prefix + ': field "' + k + '" is not supported by Cosmos-Server (not in the supported compose vocabulary)');
-        } else if (!ACCEPTED_CASINGS.has(k) && canonical !== k) {
+        } else if (canonical !== k) {
           warn(app, composeFileLabel, prefix + ': field "' + k + '" should be spelled "' + canonical + '" (canonical Cosmos field name)');
         }
       }


### PR DESCRIPTION
## Summary

Extends the servapp validator (added in #278) with network-backed checks for `description.json` `repository`, `image` and `supported_architectures`, the compose `services.*.image` keys, and mandatory/optional/unknown field schema checks.

## Checks added

### 1. Repository URL
- Must **not return an HTTP error code** → **error**.
- GitHub URL must be a **real repository** (`owner/repo`) → **warning** if a user/org page or non-repo path (verified via GitHub API).

### 2. Image validity + architecture coverage (description.json)
- Must resolve to a **valid, existing docker image** → **error** on 404 or non-image value.
- **error** when an announced arch is NOT in the image; **warning** when the image ships an unannounced arch.

### 3. Compose `services.*.image` validation
- Every `services.<service>.image` in the rendered compose must be valid/existing → **error** on 404.
- Cross-check: `description.image` must match `services.{ServiceName}.image` → **warning** on mismatch (registry aliases normalized: docker.io == registry-1.docker.io == index.docker.io == lscr.io, default tag == latest).

### 4. Mandatory / optional / undocumented fields
- **Missing mandatory field → error.** Mandatory sets derived from the fields present in (essentially) every existing app:
  - description.json: `name, description, longDescription, repository, image, tags, supported_architectures`
  - compose top-level: `services, cosmos-installer, minVersion`
  - compose service: `image, container_name, labels`
- **Undocumented field → error.** Any field NOT present in at least one existing app is rejected. Known = mandatory + curated optional:
  - description optional: `translation`
  - compose top optional: `networks, version, volumes`
  - compose service optional: `environment, volumes, restart, routes, UID, GID, user, depends_on, ports, expose, command, entrypoint, healthcheck, networks, cap_add, cap_drop, devices, device, extra_hosts, hostname, init, links, logging, network_mode, post_install, privileged, read_only, security_opt, shm_size, stdin_open, stop_grace_period, tmpfs, tty, working_dir, group_add, deploy`

### Registries supported
Docker Hub (incl. `library/` official images), ghcr.io / GitHub Packages, lscr.io / quay.io / codeberg.org / docker.n8n.io. Arch spellings canonicalized (amd64/x86, arm64/aarch64, arm/v7/armv7/arm32v7, arm/v6, 386, ppc64le, s390x, riscv64, …). Network failures degrade to **warnings**; only decisive 4xx findings are errors.

## Verified findings on the current repo (all genuine)
- **43 errors**, e.g.:
  - Bitnami images removed from Docker Hub (Dokuwiki, Drupal, Ghost, Jenkins, Moodle, Opencart, Sonarqube, Suitecrm, phpbb, redmine)
  - Removed/renamed images (readarr, lemmy + lemmy-ui, docker-webtop), missing tag (Immich)
  - Announced arch missing in image (Audacity, Dashy, Threadfin, OpenHAB, Unmanic, LynxPrompt)
  - Repo URL 404 (Plex), non-image `image` field (Minecraft-Server, Homarr)
  - **Missing `minVersion`** (15 apps: Dashy, Dozzle, Flarum, Frigate-NVR, HermitStash, Hivekeep, Lemmy, Minecraft-Bedrock-Server, Miniflux, Navidrome, Openspeedtest, Passbolt, Piped, Syncthing, phpbb)
  - **Missing `cosmos-installer`** (CashPilot, GenieACS)
- **~98 warnings** — mostly images shipping extra arches not announced, plus description/compose image mismatches (Bitnami switches, registry moves, sub-container naming).

Branch `fix/ci-repo-image-checks` on `aseracorp/resiSTORE`, based on `5b2f5b9` (3 commits).