### PR TITLE
ci: actionable error for docker-compose tmpfs/read_only idioms

### DIFF
--- a/.github/scripts/validate-servapps.js
+++ b/.github/scripts/validate-servapps.js
@@ -731,7 +731,15 @@ function checkComposeSchema(app, rendered, isYaml, composeFileLabel) {
         const nk = normalizeFieldKey(k);
         const canonical = COMPOSE_SERVICE_SUPPORTED.get(nk);
         if (!canonical) {
-          err(app, composeFileLabel, prefix + ': field "' + k + '" is not supported by Cosmos-Server (not in the supported compose vocabulary)');
+          const low = k.toLowerCase();
+          if (low === 'tmpfs' || low === 'read_only' || low === 'readonly') {
+            // tmpfs/read_only have no service-level field in Cosmos-Server's
+            // ContainerCreateRequestContainer (Go silently ignores them), but
+            // tmpfs IS supported as a volume mount type (mount.TypeTmpfs).
+            err(app, composeFileLabel, prefix + ': field "' + k + '" is NOT honored by Cosmos-Server at the service level; express ' + low + ' as a volume mount instead, e.g. volumes: [{ "type": "' + (low === 'tmpfs' ? 'tmpfs' : 'bind') + '", "target": "<path>" }] (only supported via the volumes mount list)');
+          } else {
+            err(app, composeFileLabel, prefix + ': field "' + k + '" is not supported by Cosmos-Server (not in the supported compose vocabulary)');
+          }
         } else if (canonical !== k) {
           warn(app, composeFileLabel, prefix + ': field "' + k + '" should be spelled "' + canonical + '" (canonical Cosmos field name)');
         }


### PR DESCRIPTION
## What

Improves the servapp validator's message for the docker-compose-style `tmpfs` / `read_only` service keys.

## Verified against Cosmos-Server source

Checked `azukaar/Cosmos-Server` (`v0.23.1`, `v0.23.2-unstable001`, `master`):

- `tmpfs` and `read_only` have **no service-level field** in `ContainerCreateRequestContainer` (`src/docker/api_blueprint.go`); Go's `json.Decoder` silently ignores them, so a service-level `tmpfs: [...]` / `read_only: true` does nothing.
- `tmpfs` **IS supported as a volume mount type**: the docker mount model defines `mount.TypeTmpfs` (+ `MountTmpfsOptions`), so the correct Cosmos spelling is inside `volumes`:
  ```json
  volumes: [ { type: tmpfs, target: /tmp, tmpfsOptions: { size_bytes: 67108864, mode: 1777 } } ]
  ```

## Change

Instead of the generic "not supported" message, the validator now tells authors the correct Cosmos spelling:

```
field "tmpfs" is NOT honored by Cosmos-Server at the service level; express tmpfs as a volume mount instead, e.g. volumes: [{ "type": "tmpfs", "target": "<path>" }] (only supported via the volumes mount list)
```

(same for `read_only` → `{ "type": "bind", ... }`)

Branch `fix/ci-tmpfs-message` on `aseracorp/resiSTORE`, based on `master @3baf15c` (single commit).