### PR TITLE
Revert #200 and #266 (depend on unreleased Cosmos-Server changes)

### DIFF
--- a/servapps/Audacity/cosmos-compose.json
+++ b/servapps/Audacity/cosmos-compose.json
@@ -39,7 +39,7 @@
           "type": "volume"
         }
       ],
-      "shm_size": 1073741824,
+      "shm_size": "1gb",
       "routes": [
         {
           "name": "{ServiceName}",

--- a/servapps/Blender/cosmos-compose.json
+++ b/servapps/Blender/cosmos-compose.json
@@ -39,7 +39,7 @@
           "type": "volume"
         }
       ],
-      "shm_size": 1073741824,
+      "shm_size": "1gb",
       "routes": [
         {
           "name": "{ServiceName}",

--- a/servapps/Discourse/cosmos-compose.json
+++ b/servapps/Discourse/cosmos-compose.json
@@ -15,7 +15,7 @@
       }
     ]
   },
-  "minVersion": "0.21.0",
+  "minVersion": "0.9.0",
   "services": {
     "{ServiceName}": {
       "image": "discourse/discourse:latest",

--- a/servapps/Firefox/cosmos-compose.json
+++ b/servapps/Firefox/cosmos-compose.json
@@ -39,7 +39,7 @@
           "type": "volume"
         }
       ],
-      "shm_size": 1073741824,
+      "shm_size": "1gb",
       "routes": [
         {
           "name": "{ServiceName}",

--- a/servapps/Frigate-NVR/cosmos-compose.json
+++ b/servapps/Frigate-NVR/cosmos-compose.json
@@ -21,10 +21,10 @@
              "type": "password"
           },
           {
-            "name": "sharedMemory",
-            "label": "How much shared memory in bytes do you want (default is 268435456 = 256MB)?",
-            "initialValue": "268435456",
-            "type": "text"
+             "name": "sharedMemory",
+             "label": "How much shared memory in megabytes do you want?",
+             "initialValue": "64mb",
+             "type": "text"
           },
           {
              "name": "cache",

--- a/servapps/Nextcloud/cosmos-compose.json
+++ b/servapps/Nextcloud/cosmos-compose.json
@@ -9,7 +9,7 @@
       }
     ]
   },
-  "minVersion": "0.21.0",
+  "minVersion": "0.7.6",
   "services": {
     "{ServiceName}": {
       "image": "nextcloud:production",
@@ -134,16 +134,7 @@
       "networks": {
         "{ServiceName}-databases": {}
       },
-      "command": [
-        "mariadbd",
-        "--innodb-buffer-pool-size=512M",
-        "--transaction-isolation=READ-COMMITTED",
-        "--character-set-server=utf8mb4",
-        "--collation-server=utf8mb4_unicode_ci",
-        "--max-connections=512",
-        "--innodb-rollback-on-timeout=OFF",
-        "--innodb-lock-wait-timeout=120"
-      ],
+      "command": "mariadbd --innodb-buffer-pool-size=512M --transaction-isolation=READ-COMMITTED --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --max-connections=512 --innodb-rollback-on-timeout=OFF --innodb-lock-wait-timeout=120",
       "volumes": [
         {
           "source": "{ServiceName}-mariadb-data",

--- a/servapps/Photoprism/cosmos-compose.json
+++ b/servapps/Photoprism/cosmos-compose.json
@@ -21,7 +21,7 @@
       }
     ]
   },
-  "minVersion": "0.21.0",
+  "minVersion": "0.7.6",
   "services": {
     "{ServiceName}": {
       "image": "photoprism/photoprism",
@@ -107,16 +107,7 @@
         "cosmos-stack": "{ServiceName}",
         "cosmos-stack-main": "{ServiceName}"
       },
-      "command": [
-        "mariadbd",
-        "--innodb-buffer-pool-size=512M",
-        "--transaction-isolation=READ-COMMITTED",
-        "--character-set-server=utf8mb4",
-        "--collation-server=utf8mb4_unicode_ci",
-        "--max-connections=512",
-        "--innodb-rollback-on-timeout=OFF",
-        "--innodb-lock-wait-timeout=120"
-      ],
+      "command": "mariadbd --innodb-buffer-pool-size=512M --transaction-isolation=READ-COMMITTED --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --max-connections=512 --innodb-rollback-on-timeout=OFF --innodb-lock-wait-timeout=120",
       "volumes": [
         {
           "source": "{ServiceName}-mariadb-data",

--- a/servapps/Trip/cosmos-compose.json
+++ b/servapps/Trip/cosmos-compose.json
@@ -1,6 +1,6 @@
 {
   "cosmos-installer": {},
-  "minVersion": "0.21.0",
+  "minVersion": "0.13.0",
   "services": {
     "{ServiceName}": {
       "image": "ghcr.io/itskovacs/trip:1",
@@ -33,13 +33,7 @@
               }
           }
       ],
-      "command": [
-        "fastapi",
-        "run",
-        "/app/trip/main.py",
-        "--host",
-        "0.0.0.0"
-      ]
+      "command": "fastapi run /app/trip/main.py --host 0.0.0.0"
     }
   }
 }

--- a/servapps/Webtop/cosmos-compose.json
+++ b/servapps/Webtop/cosmos-compose.json
@@ -39,7 +39,7 @@
           "type": "volume"
         }
       ],
-      "shm_size": 1073741824,
+      "shm_size": "1gb",
       "routes": [
         {
           "name": "{ServiceName}",

--- a/servapps/ntfy/cosmos-compose.json
+++ b/servapps/ntfy/cosmos-compose.json
@@ -1,13 +1,11 @@
 {
   "cosmos-installer": {},
-  "minVersion": "0.21.0",
+  "minVersion": "0.7.6",
   "services": {
     "{ServiceName}": {
       "image": "binwiederhier/ntfy",
       "container_name": "{ServiceName}",
-      "command": [
-        "serve"
-      ],
+      "command": "serve",
       "restart": "unless-stopped",
       "environment": [
         "TZ=auto",


### PR DESCRIPTION
## What this does

Reverts two PRs that were merged into `master` on 2026-08-27 but **depend on Cosmos-Server changes that are not yet released**:

- **#266** – *fix Apps: add correct shm_size* — depends on [Cosmos-Server #567](https://github.com/azukaar/Cosmos-Server/pull/567) (shm_size as bytes/INT)
- **#200** – *complementary fixes for Cosmos-Server PR #495* — depends on [Cosmos-Server #495](https://github.com/azukaar/Cosmos-Server/pull/495) (exec-form commands)

Both companion changes were merged upstream before their Cosmos-Server counterparts landed, which would break app launches for everyone on the current stable Cosmos. 

This restores the pre-merge state of the affected servapps:

| App | Restored |
|---|---|
| Discourse, Nextcloud, Photoprism, Trip, ntfy | shell-form `command` + original `minVersion` |
| Audacity, Blender, Firefox, Webtop | `shm_size: "1gb"` (string) |
| Frigate-NVR | `sharedMemory` in MB text field (`64mb`) |

## Commits reverted

- `36caa60` – fix Apps: add correct shm_size (#266)
- `99301ea` – complementary fixes for Cosmos-Server PR #495 (#200)

No conflicts: none of these files were touched by later commits on `master`.

Merging this will require a follow-up re-apply of #200/#266 once Cosmos-Server #495/#567 actually land.