### PR TITLE
fix(immich): update to v3.1.0 stack (vectorchord DB, valkey, /data mount)

### DIFF
--- a/servapps/Immich/cosmos-compose.json
+++ b/servapps/Immich/cosmos-compose.json
@@ -7,14 +7,15 @@
         "initialValue": "{DefaultDataPath}/immich-photos",
         "type": "text"
       },
-      { 
+      {
         "name": "installImmichBackup",
         "label": "Do you want to add a backup agent for the database? (https://immich.app/docs/administration/backup-and-restore)",
         "initialValue": false,
         "type": "checkbox"
       }
       {if Context.installImmichBackup}
-      , { 
+      ,
+      {
         "name": "ImmichBackupPath",
         "label": "Where do you want to save that backup?",
         "initialValue": "{DefaultDataPath}/immich-backup",
@@ -28,14 +29,14 @@
     "{ServiceName}": {
       "container_name": "{ServiceName}",
       "hostname": "{ServiceName}",
-      "image": "ghcr.io/immich-app/immich-server:release",
+      "image": "ghcr.io/immich-app/immich-server:v3.1.0",
       "networks": {
         "{ServiceName}": {}
       },
       "volumes": [
         {
           "source": "{Context.photoPath}",
-          "target": "/usr/src/app/upload",
+          "target": "/data",
           "type": "bind"
         },
         {
@@ -45,7 +46,7 @@
         }
       ],
       "labels": {
-        "cosmos-persistent-env": "UPLOAD_LOCATION, TYPESENSE_API_KEY, DB_PASSWORD, DB_DATABASE_NAME",
+        "cosmos-persistent-env": "UPLOAD_LOCATION, DB_PASSWORD, DB_DATABASE_NAME",
         "cosmos-force-network-secured": "true",
         "cosmos-auto-update": "false",
         "cosmos-icon": "https://azukaar.github.io/cosmos-servapps-official/servapps/Immich/icon.png",
@@ -53,9 +54,8 @@
         "cosmos-stack-main": "{ServiceName}"
       },
       "environment": [
-        "UPLOAD_LOCATION=/usr/src/app/upload",
-        "TYPESENSE_API_KEY={Passwords.0}",
-        "DB_PASSWORD={Passwords.1}",
+        "UPLOAD_LOCATION=/data",
+        "DB_PASSWORD={Passwords.0}",
         "DB_HOSTNAME={ServiceName}-database",
         "DB_USERNAME=postgres",
         "DB_DATABASE_NAME=immich",
@@ -89,7 +89,7 @@
     "immich-machine-learning": {
       "container_name": "immich-machine-learning",
       "hostname": "immich-machine-learning",
-      "image": "ghcr.io/immich-app/immich-machine-learning:release",
+      "image": "ghcr.io/immich-app/immich-machine-learning:v3.1.0",
       "networks": {
         "{ServiceName}": {}
       },
@@ -101,7 +101,7 @@
         }
       ],
       "labels": {
-        "cosmos-persistent-env": "UPLOAD_LOCATION, TYPESENSE_API_KEY, DB_PASSWORD, DB_DATABASE_NAME",
+        "cosmos-persistent-env": "DB_PASSWORD, DB_DATABASE_NAME",
         "cosmos-force-network-secured": "true",
         "cosmos-auto-update": "false",
         "cosmos-icon": "https://azukaar.github.io/cosmos-servapps-official/servapps/Immich/icon.png",
@@ -109,9 +109,8 @@
         "cosmos-stack-main": "{ServiceName}"
       },
       "environment": [
-        "UPLOAD_LOCATION=/usr/src/app/upload",
-        "TYPESENSE_API_KEY={Passwords.0}",
-        "DB_PASSWORD={Passwords.1}",
+        "UPLOAD_LOCATION=/data",
+        "DB_PASSWORD={Passwords.0}",
         "DB_HOSTNAME={ServiceName}-database",
         "DB_USERNAME=postgres",
         "DB_DATABASE_NAME=immich",
@@ -122,7 +121,7 @@
     "{ServiceName}-redis": {
       "container_name": "{ServiceName}-redis",
       "hostname": "{ServiceName}-redis",
-      "image": "redis:6.2-alpine@sha256:80cc8518800438c684a53ed829c621c94afd1087aaeb59b0d4343ed3e7bcf6c5",
+      "image": "docker.io/valkey/valkey:9@sha256:8e8d64b405ce18f41b8e5ee20aa4687a8ed0022d1298f2ce31cdcf3a76e09411",
       "networks": {
         "{ServiceName}": {}
       },
@@ -139,8 +138,7 @@
     "{ServiceName}-database": {
       "container_name": "{ServiceName}-database",
       "hostname": "{ServiceName}-database",
-      "image": "docker.io/tensorchord/pgvecto-rs:pg14-v0.2.0@sha256:90724186f0a3517cf6914295b5ab410db9ce23190a2d9d0b9dd6463e3fa298f0",
-      "user": "postgres",
+      "image": "ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0@sha256:bcf63357191b76a916ae5eb93464d65c07511da41e3bf7a8416db519b40b1c23",
       "networks": {
         "{ServiceName}": {}
       },
@@ -153,9 +151,10 @@
         "cosmos-stack-main": "{ServiceName}"
       },
       "environment": [
-        "POSTGRES_PASSWORD={Passwords.1}",
+        "POSTGRES_PASSWORD={Passwords.0}",
         "POSTGRES_USER=postgres",
-        "POSTGRES_DB=immich"
+        "POSTGRES_DB=immich",
+        "POSTGRES_INITDB_ARGS=--data-checksums"
       ],
       "volumes": [
         {
@@ -169,7 +168,7 @@
     {if Context.installImmichBackup}
     ,
     "{ServiceName}-backup": {
-      "image": "prodrigestivill/postgres-backup-local",
+      "image": "ghcr.io/prodrigestivill/postgres-backup-local:14",
       "container_name": "{ServiceName}-backup",
       "hostname": "{ServiceName}-backup",
       "restart": "unless-stopped",
@@ -195,7 +194,7 @@
         "POSTGRES_HOST={ServiceName}-database",
         "POSTGRES_DB=immich",
         "POSTGRES_USER=postgres",
-        "POSTGRES_PASSWORD={Passwords.1}",
+        "POSTGRES_PASSWORD={Passwords.0}",
         "SCHEDULE=@daily",
         "BACKUP_KEEP_DAYS=7",
         "BACKUP_KEEP_WEEKS=4",

--- a/servapps/Immich/description.json
+++ b/servapps/Immich/description.json
@@ -17,7 +17,7 @@
     "Immich"
   ],
   "repository": "https://github.com/immich-app/immich",
-  "image": "https://ghcr.io/immich-app/immich-server:release",
+  "image": "https://ghcr.io/immich-app/immich-server:v3.1.0",
   "supported_architectures": [
     "amd64",
     "arm64"


### PR DESCRIPTION
## Summary

Fixes the broken **Immich** servapp. The compose file was frozen at the mid-2024 stack (tensorchord/pgvecto-rs DB, Redis 6.2, Typesense, `/usr/src/app/upload`) while the `:release` tag drifted to **Immich v3.1.0**, which requires a different database image, Valkey, and the `/data` mount. This left installs broken — postgres fails to init, server unreachable (matches issues #170 and #234).

## Changes

- **Pin** `immich-server` and `immich-machine-learning` to **`v3.1.0`** — explicit upgrades instead of silently floating `:release`
- **Database**: `ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0` (was `tensorchord/pgvecto-rs`) + `POSTGRES_INITDB_ARGS=--data-checksums`
- **Cache**: `docker.io/valkey/valkey:9` (was EOL `redis:6.2-alpine`)
- **Uploads**: mount `{Context.photoPath}` → `/data` (was `/usr/src/app/upload`)
- **Drop** the obsolete `TYPESENSE_API_KEY` env
- **Backup agent**: `ghcr.io/prodrigestivill/postgres-backup-local:14` (was unmaintained `docker.io/prodrigestivill/postgres-backup-local`)
- Align `description.json` image ref to `v3.1.0`

## Validation

Rendered the template through **whiskers v0.4.0** exactly as Cosmos does (`docker-compose.jsx`): both `installImmichBackup` branches (`true`/`false`) produce valid JSON with the expected services.

| backup | services |
|---|---|
| `true` | immich, immich-machine-learning, immich-redis, immich-database, immich-backup |
| `false` | immich, immich-machine-learning, immich-redis, immich-database |

## Note

This targets **fresh installs** and corrects the packaged stack. Users with an existing install that already auto-jumped to v3 with the old DB will still need the upstream **vectorchord migration** steps — out of scope here, but worth noting.

Closes/References: #170, #234