### PR TITLE
fix(homarr): update to Homarr v1 (homarr-labs) - old image archived

### DIFF
--- a/servapps/Homarr/cosmos-compose.json
+++ b/servapps/Homarr/cosmos-compose.json
@@ -1,11 +1,33 @@
-{ 
+{
   "cosmos-installer": {
     "form": [
       {
-        "name": "icons",
-        "label": "Where do you want to store your icons?",
-        "initialValue": "{DefaultDataPath}/homarr-icons",
+        "name": "appdata",
+        "label": "Where do you want to store Homarr's data (config, database, icons)?",
+        "initialValue": "{DefaultDataPath}/homarr",
         "type": "text"
+      },
+      {
+        "name": "dockerIntegration",
+        "label": "Enable Docker integration? (Mounts the Docker socket so Homarr can manage containers - WARNING: grants Homarr control over Docker)",
+        "initialValue": false,
+        "type": "checkbox"
+      },
+      {
+        "name": "secretEncryptionKey",
+        "label": "Secret encryption key (64 hex characters) used to encrypt integration secrets in the database. MUST be exactly 64 hex chars and CANNOT be changed after install.",
+        "initialValue": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        "type": "text"
+      },
+      {
+        "name": "insecureWarning",
+        "type": "warning",
+        "label": "The default key is INSECURE. Generate your own with the following command and paste it in the field above:"
+      },
+      {
+        "name": "generateKeyInfo",
+        "type": "info",
+        "label": "openssl rand -hex 32"
       },
       {
         "name": "adminOnly",
@@ -18,12 +40,11 @@
   "minVersion": "0.8.0",
   "services": {
     "{ServiceName}": {
-      "image": "ghcr.io/ajnart/homarr:latest",
+      "image": "ghcr.io/homarr-labs/homarr:latest",
       "container_name": "{ServiceName}",
       "restart": "unless-stopped",
-      "UID": 1000,
-      "GID": 1000,
       "environment": [
+        "SECRET_ENCRYPTION_KEY={Context.secretEncryptionKey}",
         "PUID=1000",
         "PGID=1000",
         "TZ=auto"
@@ -31,24 +52,23 @@
       "labels": {
         "cosmos-force-network-secured": "true",
         "cosmos-auto-update": "true",
+        "cosmos-persistent-env": "SECRET_ENCRYPTION_KEY",
         "cosmos-icon": "https://azukaar.github.io/cosmos-servapps-official/servapps/Homarr/icon.png"
       },
       "volumes": [
         {
-          "source": "{ServiceName}-config",
-          "target": "/app/data/configs",
-          "type": "volume"
-        },
-        {
-          "source": "{ServiceName}-data",
-          "target": "/data",
-          "type": "volume"
-        },
-        {
-          "source": "{Context.icons}",
-          "target": "/app/public/icons",
+          "source": "{Context.appdata}",
+          "target": "/appdata",
           "type": "bind"
         }
+        {if Context.dockerIntegration}
+        ,
+        {
+          "source": "/var/run/docker.sock",
+          "target": "/var/run/docker.sock",
+          "type": "bind"
+        }
+        {/if}
       ],
       "routes": [
         {
@@ -65,7 +85,7 @@
           },
           "AuthEnabled": true
           {if Context.adminOnly}
-           , "AuthAdmin": true
+          , "AuthAdmin": true
           {/if}
         }
       ]

--- a/servapps/Homarr/description.json
+++ b/servapps/Homarr/description.json
@@ -1,7 +1,7 @@
 {
   "name": "Homarr",
-  "longDescription": "<p>Homarr is an open-source, self-hosted dashboard software that allows you to organize and access your web-based applications and services all in one place. It's designed to provide a central hub to simplify your web environment.</p><p>Key features of Homarr include the ability to add applications via a built-in library or by creating custom application definitions, custom themes, and the capacity to run on a desktop or mobile browser. It supports multiple users and each user can have their own personalized set of applications.</p><p>Homarr is compatible with various platforms, including Windows, Linux, MacOS, and it supports Docker, making it a highly versatile tool for various environments.</p>",
-  "description": "Homarr is an open-source, self-hosted dashboard software that provides a central hub for web-based applications and services. Features include a built-in application library, custom themes, multi-user support, and compatibility with desktop and mobile browsers. Homarr is compatible with Windows, Linux, MacOS, and Docker.",
+  "longDescription": "<p>Homarr is an open-source, self-hosted dashboard software that allows you to organize and access your web-based applications and services all in one place. It provides a central hub to simplify your web environment, with a drag-and-drop grid, built-in integrations, and authentication out of the box.</p><p>Key features include the ability to add apps via a built-in library or custom definitions, custom themes, multi-user support, and a responsive desktop/mobile interface. Homarr v1+ is maintained at homarr-labs/homarr and is the successor to the original Homarr project.</p><p>Homarr is compatible with Windows, Linux, MacOS, and Docker, making it a highly versatile tool for various environments.</p>",
+  "description": "Homarr is a sleek, modern dashboard that puts all of your apps and services at your fingertips. Built-in integrations, drag-and-drop layout, authentication out of the box, and no YAML. The successor to the original Homarr (ajnart/homarr), now maintained at homarr-labs/homarr.",
   "tags": [
     "dashboard",
     "home",
@@ -17,8 +17,8 @@
     "macos",
     "docker"
   ],
-  "repository": "https://github.com/ajnart/homarr",
-  "image": "https://ghcr.io/ajnart/homarr",
+  "repository": "https://github.com/homarr-labs/homarr",
+  "image": "https://ghcr.io/homarr-labs/homarr:latest",
   "supported_architectures": [
     "amd64",
     "arm64"


### PR DESCRIPTION
## Summary

Fixes [#268](https://github.com/azukaar/cosmos-servapps-official/issues/268) — Cosmos was installing a **very old version of Homarr**. The `ajnart/homarr` project is **archived** and its `ghcr.io/ajnart/homarr` image is frozen at the old v0.x dashboard. The project moved to **`homarr-labs/homarr`** (v1+, a complete rewrite) and is where all updates now happen.

This PR migrates the servapp to the new Homarr v1 deployment model.

## Changes

**`cosmos-compose.json`:**
- **Image**: `ghcr.io/ajnart/homarr:latest` → `ghcr.io/homarr-labs/homarr:latest` (kept `:latest` + `cosmos-auto-update: true` to match Homarr's own recommended image and the original servapp's update posture)
- **Storage**: replaced the old named volumes (`/app/data/configs`, `/data`) with a single bind mount `{DefaultDataPath}/homarr` → **`/appdata`** (v1 keeps config, sqlite DB and icons there)
- **Docker integration**: optional bind mount of `/var/run/docker.sock` (opt-in checkbox with a security warning) for the Dash/Docker integrations
- **`SECRET_ENCRYPTION_KEY`**: required by v1 to encrypt integration secrets (validated as **exactly 64 hex chars**). Added an installer form field with a default placeholder + a `warning`/`info` pair showing `openssl rand -hex 32` so users generate their own. Marked `cosmos-persistent-env` so it survives updates. (Same pattern as the Wealthfolio servapp.)
- Kept the adminOnly routing toggle and all route settings (port 7575 unchanged)

**`description.json`:**
- `repository` → `https://github.com/homarr-labs/homarr`
- `image` → `https://ghcr.io/homarr-labs/homarr:latest`
- updated short/long descriptions

## Validation

- Rendered through **whiskers v0.4.0** (same engine Cosmos + the repo validator use) for all **4 combinations** of `dockerIntegration` × `adminOnly` → all produce **valid JSON** with the correct volumes/route-keys
- Ran the repo's own `validate-servapps.js` on Homarr → **0 errors, 0 warnings** (image exists on ghcr with amd64+arm64, arch coverage matches, description.image matches primary service, schema clean)

Closes #268