### PR TITLE
fix(homebox): update to SysAdmins Media maintainer image (Fixes #185)

### DIFF
--- a/servapps/Homebox/cosmos-compose.json
+++ b/servapps/Homebox/cosmos-compose.json
@@ -1,4 +1,3 @@
-
 {
   "cosmos-installer": {
     "form": [
@@ -20,13 +19,16 @@
   "services": {
     "{ServiceName}": {
       "container_name": "{ServiceName}",
-      "image": "ghcr.io/hay-kot/homebox:latest",
+      "image": "ghcr.io/sysadminsmedia/homebox:latest",
       "environment": [
-        "HBOX_WEB_MAX_UPLOAD_SIZE={Context.maxUploadSize}"
+        "HBOX_WEB_MAX_UPLOAD_SIZE={Context.maxUploadSize}",
+        "HBOX_AUTH_API_KEY_PEPPER={Passwords.0}",
+        "HBOX_OPTIONS_ALLOW_ANALYTICS=false"
       ],
       "labels": {
         "cosmos-force-network-secured": "true",
         "cosmos-auto-update": "true",
+        "cosmos-persistent-env": "HBOX_AUTH_API_KEY_PEPPER",
         "cosmos-icon": "https://azukaar.github.io/cosmos-servapps-official/servapps/Homebox/icon.png"
       },
       "restart": "unless-stopped",

--- a/servapps/Homebox/description.json
+++ b/servapps/Homebox/description.json
@@ -1,9 +1,9 @@
 {
   "name": "Homebox",
-  "longDescription": "<p>Homebox is the inventory and organization system built for the Home User! With a focus on simplicity and ease of use, Homebox is the perfect solution for your home inventory, organization, and management needs.</p>",
+  "longDescription": "<p>Homebox is the inventory and organization system built for the Home User! With a focus on simplicity and ease of use, Homebox is the perfect solution for your home inventory, organization, and management needs. It is now maintained by SysAdmins Media after the original developer stepped down.</p>",
   "description": "Homebox is the inventory and organization system built for the Home User.",
   "tags": ["home", "homebox", "organization", "inventory", "management", "docker", "linux"],
-  "repository": "https://github.com/hay-kot/homebox",
-  "image": "https://ghcr.io/hay-kot/homebox:latest",
+  "repository": "https://github.com/sysadminsmedia/homebox",
+  "image": "https://ghcr.io/sysadminsmedia/homebox:latest",
   "supported_architectures": ["amd64", "arm64"]
-  }
+}


### PR DESCRIPTION
## What

Homebox was [abandoned by the original developer](https://sysadminsjournal.com/were-continuing-homebox-development/) and is now maintained by **SysAdmins Media**. This updates the Homebox servapp to the new upstream and image, as requested in #185.

## Changes

- **Image**: `ghcr.io/hay-kot/homebox:latest` → `ghcr.io/sysadminsmedia/homebox:latest`
- **Repository**: `https://github.com/hay-kot/homebox` → `https://github.com/sysadminsmedia/homebox`
- **New required env**: `HBOX_AUTH_API_KEY_PEPPER` — the new builds [refuse to start without it](https://homebox.software/en/quick-start/configure/). It's generated via Cosmos's `{Passwords.0}` (a random 24-char secret) and pinned with `cosmos-persistent-env` so it stays stable across container re-creations (rotating it invalidates issued API keys).
- **Telemetry**: `HBOX_OPTIONS_ALLOW_ANALYTICS=false` (opt-out, default is `false` anyway — set explicitly).
- **Description**: updated long description to mention the new maintainer.
- **Architectures**: `supported_architectures` kept as `amd64, arm64` (matches what the new GHCR manifest publishes; the old image's armv7 support was dropped upstream).

## Compatibility

Everything else is **drop-in compatible** with existing installs — the data volume (`/data`), internal port (`7745`), and upload-size env var are unchanged. The upstream [migration note](https://homebox.software/en/quick-start/) confirms switching is just an image swap. Existing Homebox users upgrading in place keep their data and API keys.

Validated locally with `node .github/scripts/validate-servapps.js Homebox` — **0 errors, 0 warnings**.