### PR TITLE
fix(piped): correct HIBERNATE env var names so the backend can reach postgres (unstable) (Fixes #155)

### DIFF
--- a/servapps/Piped/cosmos-compose.json
+++ b/servapps/Piped/cosmos-compose.json
@@ -75,11 +75,11 @@
                 "API_URL={RootProtocol}://{Hostnames.{StaticServiceName}.{StaticServiceName}.host}/api",
                 "FRONTEND_URL={RootProtocol}://{Hostnames.{StaticServiceName}.{StaticServiceName}.host}",
                 "PROXY_PART={RootProtocol}://{Hostnames.{StaticServiceName}.{StaticServiceName}.host}/proxy",
-                "HIBERNATE_CONNECTION_URL=jdbc:postgresql://{ServiceName}-postgres:5432/piped",
-                "HIBERNATE_CONNECTION_DRIVER_CLASS=org.postgresql.Driver",
-                "HIBERNATE_DIALECT=org.hibernate.dialect.PostgreSQLDialect",
-                "HIBERNATE_CONNECTION_USERNAME=piped",
-                "HIBERNATE_CONNECTION_PASSWORD={Passwords.0}"
+                "HIBERNATE__CONNECTION__URL=jdbc:postgresql://{ServiceName}-postgres:5432/piped",
+                "HIBERNATE__CONNECTION__DRIVER_CLASS=org.postgresql.Driver",
+                "HIBERNATE__DIALECT=org.hibernate.dialect.PostgreSQLDialect",
+                "HIBERNATE__CONNECTION__USERNAME=piped",
+                "HIBERNATE__CONNECTION__PASSWORD={Passwords.0}"
             ],
             "depends_on": {
                 "{ServiceName}-postgres": {}


### PR DESCRIPTION
## What

Fixes a regression in the Piped servapp (originally #155): the backend fails to start with

```
java.sql.SQLException: The url cannot be null
```

## Root cause

The compose set the backend's DB connection via `HIBERNATE_CONNECTION_URL`, `HIBERNATE_DIALECT`, etc. (**single** underscores). The backend only turns env vars into Hibernate properties when they use **double** underscores:

```java
System.getenv().forEach((key, value) -> {
    if (key.startsWith("HIBERNATE"))
        hibernateProperties.put(key.replace("__", ".").toLowerCase(), value);
});
```

Single underscores produce `hibernate_connection_url` (no dots), which Hibernate ignores, so `hibernate.connection.url` stays `null` and the backend can't reach PostgreSQL. The commit that added this is literally titled "Hibernate environment variables double underscore to period."

## Fix

Use the double-underscore form the backend expects:

- `HIBERNATE_CONNECTION_URL` → `HIBERNATE__CONNECTION__URL`
- `HIBERNATE_CONNECTION_DRIVER_CLASS` → `HIBERNATE__CONNECTION__DRIVER_CLASS`
- `HIBERNATE_DIALECT` → `HIBERNATE__DIALECT`
- `HIBERNATE_CONNECTION_USERNAME` → `HIBERNATE__CONNECTION__USERNAME`
- `HIBERNATE_CONNECTION_PASSWORD` → `HIBERNATE__CONNECTION__PASSWORD`

For example, `HIBERNATE__CONNECTION__URL` → `hibernate.connection.url` = `jdbc:postgresql://<ServiceName>-postgres:5432/piped`. The values (same-origin `/api` path routing from #289, `{Passwords.0}` DB password) are unchanged.

## Note

This fixes the **`unstable`** Piped servapp (the squash-merged #289). The `master` Piped PR (#288) has the same single-underscore bug and will need the same one-line correction if/when it merges.

## Validation

- whiskers render: env vars now transform to `hibernate.connection.url`, `hibernate.dialect`, etc.
- `node .github/scripts/validate-servapps.js Piped` → **0 errors, 0 warnings**

Closes #155.