### PR TITLE
fix(piped): align with upstream - drop custom network, add bg-helper, fix volumes (unstable) (Fixes #155)

### DIFF
--- a/servapps/Piped/cosmos-compose.json
+++ b/servapps/Piped/cosmos-compose.json
@@ -35,9 +35,6 @@
             "depends_on": {
                 "{ServiceName}-backend": {}
             },
-            "networks": {
-                "{ServiceName}-net": {}
-            },
             "routes": [
                 {
                     "name": "{ServiceName}",
@@ -75,6 +72,7 @@
                 "API_URL={RootProtocol}://{Hostnames.{StaticServiceName}.{StaticServiceName}.host}/api",
                 "FRONTEND_URL={RootProtocol}://{Hostnames.{StaticServiceName}.{StaticServiceName}.host}",
                 "PROXY_PART={RootProtocol}://{Hostnames.{StaticServiceName}.{StaticServiceName}.host}/proxy",
+                "BG_HELPER_URL={RootProtocol}://{Hostnames.{StaticServiceName}.{StaticServiceName}.host}/bg-helper",
                 "HIBERNATE__CONNECTION__URL=jdbc:postgresql://{ServiceName}-postgres:5432/piped",
                 "HIBERNATE__CONNECTION__DRIVER_CLASS=org.postgresql.Driver",
                 "HIBERNATE__DIALECT=org.hibernate.dialect.PostgreSQLDialect",
@@ -83,16 +81,6 @@
             ],
             "depends_on": {
                 "{ServiceName}-postgres": {}
-            },
-            "volumes": [
-                {
-                    "source": "{ServiceName}-backend",
-                    "target": "/app",
-                    "type": "volume"
-                }
-            ],
-            "networks": {
-                "{ServiceName}-net": {}
             },
             "routes": [
                 {
@@ -104,6 +92,41 @@
                     "PathPrefix": "/api",
                     "StripPathPrefix": true,
                     "target": "http://{ServiceName}-backend:8080",
+                    "mode": "SERVAPP",
+                    "Timeout": 14400000,
+                    "ThrottlePerMinute": 12000,
+                    "BlockCommonBots": true,
+                    "HideFromDashboard": true,
+                    "SmartShield": {
+                        "Enabled": true
+                    }
+                }
+            ]
+        },
+        "{ServiceName}-bg-helper": {
+            "image": "1337kavin/bg-helper-server:latest",
+            "container_name": "{ServiceName}-bg-helper",
+            "restart": "unless-stopped",
+            "labels": {
+                "cosmos-force-network-secured": "true",
+                "cosmos-auto-update": "true",
+                "cosmos-icon": "https://azukaar.github.io/cosmos-servapps-official/servapps/Piped/icon.png",
+                "cosmos-stack": "{ServiceName}",
+                "cosmos-stack-main": "{ServiceName}"
+            },
+            "depends_on": {
+                "{ServiceName}-backend": {}
+            },
+            "routes": [
+                {
+                    "name": "{ServiceName}-bg-helper",
+                    "description": "Piped background helper (same origin)",
+                    "useHost": true,
+                    "Host": "{Hostnames.{StaticServiceName}.{StaticServiceName}.host}",
+                    "UsePathPrefix": true,
+                    "PathPrefix": "/bg-helper",
+                    "StripPathPrefix": true,
+                    "target": "http://{ServiceName}-bg-helper:3000",
                     "mode": "SERVAPP",
                     "Timeout": 14400000,
                     "ThrottlePerMinute": 12000,
@@ -132,9 +155,6 @@
             "depends_on": {
                 "{ServiceName}-backend": {}
             },
-            "networks": {
-                "{ServiceName}-net": {}
-            },
             "routes": [
                 {
                     "name": "{ServiceName}-proxy",
@@ -157,7 +177,7 @@
             ]
         },
         "{ServiceName}-postgres": {
-            "image": "postgres:17-alpine",
+            "image": "pgautoupgrade/pgautoupgrade:16-alpine",
             "container_name": "{ServiceName}-postgres",
             "restart": "unless-stopped",
             "labels": {
@@ -179,13 +199,7 @@
                     "target": "/var/lib/postgresql/data",
                     "type": "volume"
                 }
-            ],
-            "networks": {
-                "{ServiceName}-net": {}
-            }
+            ]
         }
-    },
-    "networks": {
-        "{ServiceName}-net": {}
     }
 }


### PR DESCRIPTION
## What

Aligns the Piped servapp with the upstream reference — [TeamPiped/Piped-Docker `docker-compose.standalone.yml`](https://raw.githubusercontent.com/TeamPiped/Piped-Docker/refs/heads/main/template/docker-compose.standalone.yml).

The previous Piped temped created a custom docker network, which is unnecessary: Cosmos already puts every container of a stack on its own default network (named after the stack), so containers reach each other by `container_name` without any explicit `networks` block.

## Changes (`servapps/Piped/cosmos-compose.json`)

1. **Remove the custom `{ServiceName}-net` network** — dropped the per-service `networks:` blocks and the top-level `networks:` declaration. Cosmos's default stack network handles inter-container DNS (same fix applied to the master PR #288).
2. **Add the missing `bg-helper` service** — upstream runs `1337kavin/bg-helper-server` (port 3000). Added the container + a same-origin `/bg-helper` route and wired `BG_HELPER_URL` on the backend.
3. **Remove the backend `/app` volume** — mounting an empty named volume over `/app` would shadow `piped.jar` inside the image and break startup. The backend reads every setting from env vars first (`getProperty` checks `System.getenv(key)` before `config.properties`), so no config file or `/app` mount is needed.
4. **Postgres → `pgautoupgrade/pgautoupgrade:16-alpine`** — matches upstream and auto-migrates the data directory on PG major upgrades (instead of plain `postgres:17-alpine`).

Route layout stays same-origin (no CORS, matches the design from #289):
```
/           -> frontend
/api/*      -> backend  (strip prefix)
/proxy/*    -> proxy    (strip prefix)
/bg-helper/*-> bg-helper (strip prefix)
```

## Validation
- `node .github/scripts/validate-servapps.js Piped` → **0 errors, 0 warnings**.
- Whiskers render verified: no `networks` keys anywhere; all 4 services on Cosmos default network; routes/targets correct.