### PR TITLE
fix(piped): connect containers via internal docker network, not cosmos routes (unstable) (Fixes #155)

### DIFF
--- a/servapps/Piped/cosmos-compose.json
+++ b/servapps/Piped/cosmos-compose.json
@@ -72,7 +72,8 @@
                 "API_URL={RootProtocol}://{Hostnames.{StaticServiceName}.{StaticServiceName}.host}/api",
                 "FRONTEND_URL={RootProtocol}://{Hostnames.{StaticServiceName}.{StaticServiceName}.host}",
                 "PROXY_PART={RootProtocol}://{Hostnames.{StaticServiceName}.{StaticServiceName}.host}/proxy",
-                "BG_HELPER_URL={RootProtocol}://{Hostnames.{StaticServiceName}.{StaticServiceName}.host}/bg-helper",
+                "PUBSUB_URL={RootProtocol}://{Hostnames.{StaticServiceName}.{StaticServiceName}.host}/api",
+                "BG_HELPER_URL=http://{ServiceName}-bg-helper:3000",
                 "HIBERNATE__CONNECTION__URL=jdbc:postgresql://{ServiceName}-postgres:5432/piped",
                 "HIBERNATE__CONNECTION__DRIVER_CLASS=org.postgresql.Driver",
                 "HIBERNATE__DIALECT=org.hibernate.dialect.PostgreSQLDialect",
@@ -116,27 +117,7 @@
             },
             "depends_on": {
                 "{ServiceName}-backend": {}
-            },
-            "routes": [
-                {
-                    "name": "{ServiceName}-bg-helper",
-                    "description": "Piped background helper (same origin)",
-                    "useHost": true,
-                    "Host": "{Hostnames.{StaticServiceName}.{StaticServiceName}.host}",
-                    "UsePathPrefix": true,
-                    "PathPrefix": "/bg-helper",
-                    "StripPathPrefix": true,
-                    "target": "http://{ServiceName}-bg-helper:3000",
-                    "mode": "SERVAPP",
-                    "Timeout": 14400000,
-                    "ThrottlePerMinute": 12000,
-                    "BlockCommonBots": true,
-                    "HideFromDashboard": true,
-                    "SmartShield": {
-                        "Enabled": true
-                    }
-                }
-            ]
+            }
         },
         "{ServiceName}-proxy": {
             "image": "1337kavin/piped-proxy:latest",


### PR DESCRIPTION
## What

Follow-up to the already-merged #300. The merged version wired `BG_HELPER_URL` to a **public `/bg-helper` Cosmos route** — that's wrong.

## Why

The Piped backend consumes `BG_HELPER_URL` **server-side**:

```java
// BgPoTokenProvider.java
String poToken = ReqwestUtils.fetch(bgHelperUrl + "/generate", "POST", ...);
```

This is a container-to-container call over the Docker network, **not** a browser request. It should never round-trip through Cosmos's HTTP proxy/route.

## Changes

- **`BG_HELPER_URL`**: `https://<host>/bg-helper` → `http://{ServiceName}-bg-helper:3000` (direct internal network URL, same as `HIBERNATE__CONNECTION__URL`)
- **Remove the `/bg-helper` Cosmos route** entirely — bg-helper is internal-only
- **Add explicit `PUBSUB_URL`** = public `https://<host>/api` — the backend uses this to register WebSub callbacks (`/api/webhooks/pubsub` → backend `/webhooks/pubsub`) which **must** be reachable from the internet, so this one correctly stays public (it defaults to `API_URL`, but now it's explicit)

## What stays public (browser-facing, correct)

`API_URL`, `FRONTEND_URL`, `PROXY_PART` are returned in backend API responses and fetched by the **browser**, so they correctly keep the same-origin Cosmos routes (`/api`, `/proxy`).

In short: **server-to-server connections use the internal Docker network (`http://{ServiceName}-...:PORT`); only browser-facing traffic goes through Cosmos routes.**

## Validation
- `node .github/scripts/validate-servapps.js Piped` → **0 errors, 0 warnings**
- Render verified: bg-helper has no routes; `BG_HELPER_URL` is internal; `PUBSUB_URL` public.