### PR TITLE
fix(ghost): wait for MySQL to become healthy before starting Ghost (ECONNREFUSED :3306 startup race)

### DIFF
--- a/servapps/Ghost/cosmos-compose.json
+++ b/servapps/Ghost/cosmos-compose.json
@@ -37,6 +37,11 @@
         "cosmos-stack": "{ServiceName}",
         "cosmos-stack-main": "{ServiceName}"
       },
+      "depends_on": {
+        "{ServiceName}-db": {
+          "condition": "service_healthy"
+        }
+      },
       "routes": [
         {
           "name": "{ServiceName}",
@@ -66,6 +71,19 @@
         "MYSQL_USER=ghost",
         "MYSQL_PASSWORD={Passwords.2}"
       ],
+      "healthcheck": {
+        "test": [
+          "CMD",
+          "mysqladmin",
+          "ping",
+          "-h",
+          "localhost"
+        ],
+        "interval": 10,
+        "timeout": 20,
+        "retries": 10,
+        "start_period": 60
+      },
       "labels": {
         "cosmos-persistent-env": "MYSQL_ROOT_PASSWORD, MYSQL_DATABASE, MYSQL_USER, MYSQL_PASSWORD",
         "cosmos-stack": "{ServiceName}",


### PR DESCRIPTION
## Problem

Ghost fails to start with:

```
ERROR connect ECONNREFUSED 172.16.2.83:3306
"Unknown database error"
Error ID: 500
```

This is a **startup race**, not a DNS/network problem (the IP resolves — it's the DB container's address on the stack network).

- `ghost:5-alpine` boots in seconds and tries to connect immediately
- `mysql:8.0`'s **first-boot data-dir initialization takes 30–90s** (empty volume → init → create DB/user/grants)
- Ghost's `DatabaseStateManager.makeReady()` does **not retry** — on connection failure it throws `InternalServerError` (`code: DATABASE_ERROR`) and the app stays on its boot-time error page ("Unknown database error", Error ID 500)

The current template (post #222) has **no `depends_on`** and **no DB healthcheck**, so Cosmos starts both containers in parallel — on fresh installs and on every restart after the DB was stopped.

## Fix

Following the same pattern already used by **Scada-LTS** and **Miniflux** in this repo:

1. Add a `mysqladmin ping` healthcheck to `{ServiceName}-db` so Cosmos knows when MySQL is actually accepting connections.
2. Add `depends_on: { "{ServiceName}-db": { "condition": "service_healthy" } }` on the Ghost service.

Cosmos's backend (`src/docker/depends_on.go`) fully supports `service_healthy` conditions — it waits (up to 10 min) for the dependency to be healthy before starting the dependent, and the frontend compose editor preserves these fields. This eliminates the race on both fresh installs and restarts.

## Validation

- `node .github/scripts/validate-servapps.js` → **144 apps checked, 0 errors** (only pre-existing warnings)
- Template renders cleanly with the same whiskers context Cosmos uses at install time (service names, `{Passwords}`, `{Hostnames}` all resolve; `depends_on`/`healthcheck` come through intact)