### PR TITLE
fix: remove redundant per-service custom networks from 36 templates

### DIFF
--- a/servapps/Cachet/cosmos-compose.json
+++ b/servapps/Cachet/cosmos-compose.json
@@ -27,9 +27,6 @@
                 "cosmos-stack": "{ServiceName}",
                 "cosmos-stack-main": "{ServiceName}"
             },
-            "networks": {
-                "{ServiceName}-postgres": {}
-            },
             "routes": [{
                 "name": "{ServiceName}",
                 "description": "Expose {ServiceName} to the web",
@@ -50,9 +47,6 @@
             "container_name": "{ServiceName}-postgres",
             "hostname": "{ServiceName}-postgres",
             "restart": "unless-stopped",
-            "networks": {
-                "{ServiceName}-postgres": {}
-            },
             "stop_grace_period": 5,
             "security_opt": [
                 "seccomp:unconfined",
@@ -74,9 +68,5 @@
                 "POSTGRES_PASSWORD={Passwords.0}"
             ]
         }
-    },
-
-    "networks": {
-        "{ServiceName}-postgres": {}
     }
 }

--- a/servapps/CashPilot/cosmos-compose.json
+++ b/servapps/CashPilot/cosmos-compose.json
@@ -22,9 +22,6 @@
         "cosmos-stack": "{ServiceName}",
         "cosmos-stack-main": "{ServiceName}"
       },
-      "networks": {
-        "{ServiceName}-network": {}
-      },
       "routes": [
         {
           "name": "{ServiceName}",
@@ -58,13 +55,7 @@
       "labels": {
         "cosmos-stack": "{ServiceName}",
         "cosmos-stack-main": "{ServiceName}"
-      },
-      "networks": {
-        "{ServiceName}-network": {}
       }
     }
-  },
-  "networks": {
-    "{ServiceName}-network": {}
   }
 }

--- a/servapps/Discourse/cosmos-compose.json
+++ b/servapps/Discourse/cosmos-compose.json
@@ -43,9 +43,6 @@
         "cosmos-stack": "{ServiceName}",
         "cosmos-stack-main": "{ServiceName}"
       },
-      "networks": {
-        "{ServiceName}-postgres": {}
-      },
       "volumes": [
         {
           "source": "{ServiceName}-discourse_data",
@@ -97,9 +94,6 @@
         "cosmos-stack": "{ServiceName}",
         "cosmos-stack-main": "{ServiceName}"
       },
-      "networks": {
-        "{ServiceName}-postgres": {}
-      },
       "volumes": [
         {
           "source": "{ServiceName}-sidekiq_data",
@@ -113,9 +107,6 @@
       "container_name": "{ServiceName}-postgres",
       "hostname": "{ServiceName}-postgres",
       "restart": "unless-stopped",
-      "networks": {
-        "{ServiceName}-postgres": {}
-      },
       "stop_grace_period": 5,
       "security_opt": [
         "seccomp:unconfined",
@@ -144,9 +135,6 @@
       "container_name": "{ServiceName}-redis",
       "hostname": "{ServiceName}-redis",
       "restart": "unless-stopped",
-      "networks": {
-        "{ServiceName}-postgres": {}
-      },
       "volumes": [
         {
           "source": "{ServiceName}-redis",
@@ -161,10 +149,6 @@
       },
       "command": "redis-server --requirepass {Passwords.1} --appendonly yes",
       "environment": []
-    }
-  },
-  "networks": {
-    "{ServiceName}-postgres": {
     }
   }
 }

--- a/servapps/Drupal/cosmos-compose.json
+++ b/servapps/Drupal/cosmos-compose.json
@@ -20,7 +20,6 @@
         { "source": "{ServiceName}-themes", "target": "/var/www/html/themes", "type": "volume" },
         { "source": "{ServiceName}-sites", "target": "/var/www/html/sites", "type": "volume" }
       ],
-      "networks": { "{ServiceName}": {} },
       "labels": {
         "cosmos-force-network-secured": "true",
         "cosmos-auto-update": "true",
@@ -47,7 +46,6 @@
       "container_name": "{ServiceName}-db",
       "hostname": "{ServiceName}-db",
       "restart": "unless-stopped",
-      "networks": { "{ServiceName}": {} },
       "volumes": [
         { "source": "{ServiceName}-db", "target": "/var/lib/mysql", "type": "volume" }
       ],
@@ -63,6 +61,5 @@
         "cosmos-stack-main": "{ServiceName}"
       }
     }
-  },
-  "networks": { "{ServiceName}": {} }
+  }
 }

--- a/servapps/Firefly-III/cosmos-compose.json
+++ b/servapps/Firefly-III/cosmos-compose.json
@@ -27,9 +27,6 @@
         "cosmos-stack": "{ServiceName}",
         "cosmos-stack-main": "{ServiceName}"
       },
-      "networks": {
-        "{ServiceName}": {}
-      },
       "volumes": [
         {
           "source": "{ServiceName}-upload",
@@ -59,9 +56,6 @@
       "container_name": "{ServiceName}-db",
       "hostname": "{ServiceName}-db",
       "restart": "unless-stopped",
-      "networks": {
-        "{ServiceName}": {}
-      },
       "volumes": [
         {
           "source": "{ServiceName}-db",
@@ -81,9 +75,5 @@
         "cosmos-stack-main": "{ServiceName}"
       }
     }
-  },
-
-  "networks": {
-    "{ServiceName}": {}
   }
 }

--- a/servapps/Flarum/cosmos-compose.json
+++ b/servapps/Flarum/cosmos-compose.json
@@ -24,9 +24,6 @@
        "{ServiceName}": {
           "image": "mondedie/flarum:stable",
           "container_name": "{ServiceName}",
-          "networks": {
-             "{ServiceName}-net": {}
-          },
           "routes": [
              {
                 "name": "{ServiceName}",
@@ -89,9 +86,6 @@
           "hostname": "{ServiceName}-mariadb",
           "image": "mariadb:10.5",
           "container_name": "{ServiceName}-mariadb",
-          "networks": {
-             "{ServiceName}-net": {}
-          },
           "environment": [
              "MYSQL_ROOT_PASSWORD={Passwords.0}",
              "MYSQL_DATABASE={ServiceName}-mariadb",
@@ -113,8 +107,5 @@
              "cosmos-stack-main": "{ServiceName}"
           }
        }
-    },
-    "networks": {
-       "{ServiceName}-net": {}
     }
  }

--- a/servapps/GenieACS/cosmos-compose.json
+++ b/servapps/GenieACS/cosmos-compose.json
@@ -26,9 +26,6 @@
         "cosmos-stack": "{ServiceName}",
         "cosmos-stack-main": "{ServiceName}"
       },
-      "networks": {
-        "{ServiceName}-network": {}
-      },
       "routes": [
         {
           "name": "{ServiceName}",
@@ -60,13 +57,7 @@
       "labels": {
         "cosmos-stack": "{ServiceName}",
         "cosmos-stack-main": "{ServiceName}"
-      },
-      "networks": {
-        "{ServiceName}-network": {}
       }
     }
-  },
-  "networks": {
-    "{ServiceName}-network": {}
   }
 }

--- a/servapps/Ghost/cosmos-compose.json
+++ b/servapps/Ghost/cosmos-compose.json
@@ -28,7 +28,6 @@
       "volumes": [
         { "source": "{ServiceName}-content", "target": "/var/lib/ghost/content", "type": "volume" }
       ],
-      "networks": { "{ServiceName}": {} },
       "labels": {
         "cosmos-persistent-env": "url, database__connection__password, database__connection__database, database__connection__user",
         "cosmos-force-network-secured": "true",
@@ -61,7 +60,6 @@
       "container_name": "{ServiceName}-db",
       "hostname": "{ServiceName}-db",
       "restart": "unless-stopped",
-      "networks": { "{ServiceName}": {} },
       "volumes": [
         { "source": "{ServiceName}-db", "target": "/var/lib/mysql", "type": "volume" }
       ],
@@ -90,6 +88,5 @@
         "cosmos-stack-main": "{ServiceName}"
       }
     }
-  },
-  "networks": { "{ServiceName}": {} }
+  }
 }

--- a/servapps/Immich/cosmos-compose.json
+++ b/servapps/Immich/cosmos-compose.json
@@ -30,9 +30,6 @@
       "container_name": "{ServiceName}",
       "hostname": "{ServiceName}",
       "image": "ghcr.io/immich-app/immich-server:v3.1.0",
-      "networks": {
-        "{ServiceName}": {}
-      },
       "volumes": [
         {
           "source": "{Context.photoPath}",
@@ -90,9 +87,6 @@
       "container_name": "immich-machine-learning",
       "hostname": "immich-machine-learning",
       "image": "ghcr.io/immich-app/immich-machine-learning:v3.1.0",
-      "networks": {
-        "{ServiceName}": {}
-      },
       "volumes": [
         {
           "source": "{ServiceName}-model-cache",
@@ -122,9 +116,6 @@
       "container_name": "{ServiceName}-redis",
       "hostname": "{ServiceName}-redis",
       "image": "docker.io/valkey/valkey:9@sha256:8e8d64b405ce18f41b8e5ee20aa4687a8ed0022d1298f2ce31cdcf3a76e09411",
-      "networks": {
-        "{ServiceName}": {}
-      },
       "labels": {
         "cosmos-persistent-env": "POSTGRES_PASSWORD, POSTGRES_USER, POSTGRES_DB",
         "cosmos-force-network-secured": "true",
@@ -139,9 +130,6 @@
       "container_name": "{ServiceName}-database",
       "hostname": "{ServiceName}-database",
       "image": "ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0@sha256:bcf63357191b76a916ae5eb93464d65c07511da41e3bf7a8416db519b40b1c23",
-      "networks": {
-        "{ServiceName}": {}
-      },
       "labels": {
         "cosmos-persistent-env": "POSTGRES_PASSWORD, POSTGRES_USER, POSTGRES_DB",
         "cosmos-force-network-secured": "true",
@@ -180,9 +168,6 @@
         "cosmos-stack": "{ServiceName}",
         "cosmos-stack-main": "{ServiceName}"
       },
-      "networks": {
-        "{ServiceName}": {}
-      },
       "volumes": [
         {
           "source": "{Context.ImmichBackupPath}",
@@ -208,9 +193,5 @@
       }
     }
     {/if}
-  },
-    
-  "networks": {
-    "{ServiceName}": {}
   }
 }

--- a/servapps/Jellystat/cosmos-compose.json
+++ b/servapps/Jellystat/cosmos-compose.json
@@ -39,9 +39,6 @@
         "cosmos-stack": "{ServiceName}",
         "cosmos-stack-main": "{ServiceName}"
       },
-      "networks": {
-        "{ServiceName}-databases": {}
-      },
       "volumes": [
         {
           "source": "{ServiceName}-postgres-data",
@@ -69,9 +66,6 @@
         "cosmos-icon": "https://azukaar.github.io/cosmos-servapps-official/servapps/Jellystat/icon.png",
         "cosmos-stack": "{ServiceName}",
         "cosmos-stack-main": "{ServiceName}"
-      },
-      "networks": {
-        "{ServiceName}-databases": {}
       },
       "depends_on": {
         "{ServiceName}-db": {}
@@ -109,8 +103,5 @@
         {/if}
       ]
     }
-  },
-  "networks": {
-    "{ServiceName}-databases": {}
   }
 }

--- a/servapps/Joplin/cosmos-compose.json
+++ b/servapps/Joplin/cosmos-compose.json
@@ -32,9 +32,6 @@
         "cosmos-stack": "{ServiceName}",
         "cosmos-stack-main": "{ServiceName}"
       },
-      "networks": {
-        "{ServiceName}-postgres": {}
-      },
       "routes": [
         {
           "name": "{ServiceName}",
@@ -62,9 +59,6 @@
         "seccomp:unconfined",
         "apparmor:unconfined"
       ],
-      "networks": {
-        "{ServiceName}-postgres": {}
-      },
       "volumes": [
         {
           "source": "{ServiceName}-postgres-data",
@@ -82,11 +76,6 @@
         "cosmos-stack": "{ServiceName}",
         "cosmos-stack-main": "{ServiceName}"
       }
-    }
-  },
-
-  "networks": {
-    "{ServiceName}-postgres": {
     }
   }
 }

--- a/servapps/Keycloak/cosmos-compose.json
+++ b/servapps/Keycloak/cosmos-compose.json
@@ -32,7 +32,6 @@
         "cosmos-stack": "{ServiceName}",
         "cosmos-stack-main": "{ServiceName}"
       },
-      "networks": { "{ServiceName}-postgres": {} },
       "routes": [
         {
           "name": "{ServiceName}",
@@ -52,7 +51,6 @@
       "container_name": "{ServiceName}-postgres",
       "hostname": "{ServiceName}-postgres",
       "restart": "unless-stopped",
-      "networks": { "{ServiceName}-postgres": {} },
       "volumes": [
         { "source": "{ServiceName}-postgres-data", "target": "/var/lib/postgresql/data", "type": "volume" }
       ],
@@ -67,6 +65,5 @@
         "POSTGRES_PASSWORD={Passwords.0}"
       ]
     }
-  },
-  "networks": { "{ServiceName}-postgres": {} }
+  }
 }

--- a/servapps/Kitchenowl/cosmos-compose.json
+++ b/servapps/Kitchenowl/cosmos-compose.json
@@ -16,9 +16,6 @@
                 "cosmos-stack": "{ServiceName}",
                 "cosmos-stack-main": "{ServiceName}"
             },
-            "networks": {
-                "{ServiceName}-network": {}
-            },
             "environment": [
                 "BACK_URL={ServiceName}-backend:5000"
             ],
@@ -50,9 +47,6 @@
                 "cosmos-stack": "{ServiceName}",
                 "cosmos-stack-main": "{ServiceName}"
             },
-            "networks": {
-                "{ServiceName}-network": {}
-            },
             "volumes": [
                 {
                     "source": "{ServiceName}-data",
@@ -65,8 +59,5 @@
                 "JWT_SECRET_KEY={Passwords.0}"
             ]
         }
-    },
-    "networks": {
-        "{ServiceName}-network": {}
     }
 }

--- a/servapps/LynxPrompt/cosmos-compose.json
+++ b/servapps/LynxPrompt/cosmos-compose.json
@@ -46,9 +46,6 @@
         "cosmos-stack": "{ServiceName}",
         "cosmos-stack-main": "{ServiceName}"
       },
-      "networks": {
-        "{ServiceName}-network": {}
-      },
       "depends_on": [
         "{ServiceName}-db"
       ],
@@ -89,13 +86,7 @@
         "cosmos-persistent-env": "POSTGRES_DB, POSTGRES_USER, POSTGRES_PASSWORD",
         "cosmos-stack": "{ServiceName}",
         "cosmos-stack-main": "{ServiceName}"
-      },
-      "networks": {
-        "{ServiceName}-network": {}
       }
     }
-  },
-  "networks": {
-    "{ServiceName}-network": {}
   }
 }

--- a/servapps/Manyfold/cosmos-compose.json
+++ b/servapps/Manyfold/cosmos-compose.json
@@ -51,9 +51,6 @@
         "cosmos-stack": "{ServiceName}",
         "cosmos-stack-main": "{ServiceName}"
       },
-      "networks": {
-        "{ServiceName}-data": {}
-      },
       "volumes": [
         {if Context.modelPaths}
         {
@@ -89,9 +86,6 @@
       "image": "redis:7-alpine",
       "container_name": "{ServiceName}-redis",
       "hostname": "{ServiceName}-redis",
-      "networks": {
-        "{ServiceName}-data": {}
-      },
       "labels": {
         "cosmos-force-network-secured": "true",
         "cosmos-auto-update": "true",
@@ -115,9 +109,6 @@
       "hostname": "{ServiceName}-postgres",
       "restart": "unless-stopped",
       "stop_grace_period": 5,
-      "networks": {
-        "{ServiceName}-data": {}
-      },
       "labels": {
         "cosmos-persistent-env": "POSTGRES_DB, POSTGRES_USER, POSTGRES_PASSWORD",
         "cosmos-force-network-secured": "true",
@@ -138,11 +129,6 @@
         "POSTGRES_USER=manyfold",
         "POSTGRES_PASSWORD={Passwords.0}"
       ]
-    }
-  },
-
-  "networks": {
-    "{ServiceName}-data": {
     }
   }
 }

--- a/servapps/Mastodon/cosmos-compose.json
+++ b/servapps/Mastodon/cosmos-compose.json
@@ -68,9 +68,6 @@
         "cosmos-stack": "{ServiceName}",
         "cosmos-stack-main": "{ServiceName}"
       },
-      "networks": {
-        "{ServiceName}-data": {}
-      },
       "volumes": [
         {
           "source": "{ServiceName}-config",
@@ -105,9 +102,6 @@
       "image": "redis:7-alpine",
       "container_name": "{ServiceName}-redis",
       "hostname": "{ServiceName}-redis",
-      "networks": {
-        "{ServiceName}-data": {}
-      },
       "labels": {
         "cosmos-force-network-secured": "true",
         "cosmos-auto-update": "true",
@@ -135,9 +129,6 @@
         "seccomp:unconfined",
         "apparmor:unconfined"
       ],
-      "networks": {
-        "{ServiceName}-data": {}
-      },
       "labels": {
         "cosmos-persistent-env": "POSTGRES_DB, POSTGRES_USER, POSTGRES_PASSWORD",
         "cosmos-force-network-secured": "true",
@@ -158,11 +149,6 @@
         "POSTGRES_USER=mastodon",
         "POSTGRES_PASSWORD={Passwords.0}"
       ]
-    }
-  },
-  
-  "networks": {
-    "{ServiceName}-data": {
     }
   }
 }

--- a/servapps/MediaWiki/cosmos-compose.json
+++ b/servapps/MediaWiki/cosmos-compose.json
@@ -17,7 +17,6 @@
       "volumes": [
         { "source": "{ServiceName}-images", "target": "/var/www/html/images", "type": "volume" }
       ],
-      "networks": { "{ServiceName}": {} },
       "labels": {
         "cosmos-force-network-secured": "true",
         "cosmos-auto-update": "true",
@@ -44,7 +43,6 @@
       "container_name": "{ServiceName}-db",
       "hostname": "{ServiceName}-db",
       "restart": "unless-stopped",
-      "networks": { "{ServiceName}": {} },
       "volumes": [
         { "source": "{ServiceName}-db", "target": "/var/lib/mysql", "type": "volume" }
       ],
@@ -60,6 +58,5 @@
         "cosmos-stack-main": "{ServiceName}"
       }
     }
-  },
-  "networks": { "{ServiceName}": {} }
+  }
 }

--- a/servapps/Miniflux/cosmos-compose.json
+++ b/servapps/Miniflux/cosmos-compose.json
@@ -52,9 +52,6 @@
               "condition": "service_healthy"
           }
         },
-        "networks": {
-          "{ServiceName}-data": {}
-        },
         "healthcheck": {
           "test": [
             "CMD",
@@ -97,9 +94,6 @@
           "interval": 10,
           "start_period": 30
         },
-        "networks": {
-          "{ServiceName}-data": {}
-        },
         "labels": {
           "cosmos-persistent-env": "POSTGRES_DB, POSTGRES_USER, POSTGRES_PASSWORD",
           "cosmos-force-network-secured": "true",
@@ -120,11 +114,6 @@
           "POSTGRES_USER=miniflux",
           "POSTGRES_PASSWORD={Passwords.0}"
         ]
-      }
-    },
-  
-    "networks": {
-      "{ServiceName}-data": {
       }
     }
   }

--- a/servapps/Monica/cosmos-compose.json
+++ b/servapps/Monica/cosmos-compose.json
@@ -24,9 +24,6 @@
           "APP_URL=https://{Hostnames.{StaticServiceName}.{StaticServiceName}.host}",
           "APP_ENV=production"
         ],
-        "networks": {
-            "{ServiceName}": {}
-          },
           "labels": {
             "cosmos-persistent-env": "DB_PASSWORD, DB_HOST, DB_PORT, DB_USERNAME",
             "cosmos-force-network-secured": "true",
@@ -55,9 +52,6 @@
         "container_name": "{ServiceName}-db",
         "hostname": "{ServiceName}-db",
         "restart": "unless-stopped",
-        "networks": {
-            "{ServiceName}": {}
-          },
         "volumes": [
           {
             "source": "{ServiceName}-db",
@@ -78,8 +72,5 @@
           "cosmos-stack-main": "{ServiceName}"
         }
       }
-    },
-    "networks": {
-        "{ServiceName}": {}
-      }
+    }
   }

--- a/servapps/Moodle/cosmos-compose.json
+++ b/servapps/Moodle/cosmos-compose.json
@@ -30,7 +30,6 @@
         "MOODLE_PASSWORD={Context.MOODLE_PASSWORD}",
         "MOODLE_EMAIL={Context.MOODLE_EMAIL}"
       ],
-      "networks": { "{ServiceName}": {} },
       "labels": {
         "cosmos-persistent-env": "MOODLE_DATABASE_HOST, MOODLE_DATABASE_PORT_NUMBER, MOODLE_DATABASE_USER, MOODLE_DATABASE_NAME, MOODLE_DATABASE_PASSWORD",
         "cosmos-force-network-secured": "true",
@@ -58,7 +57,6 @@
       "container_name": "{ServiceName}-db",
       "hostname": "{ServiceName}-db",
       "restart": "unless-stopped",
-      "networks": { "{ServiceName}": {} },
       "volumes": [
         { "source": "{ServiceName}-db", "target": "/var/lib/mysql", "type": "volume" }
       ],
@@ -74,6 +72,5 @@
         "cosmos-stack-main": "{ServiceName}"
       }
     }
-  },
-  "networks": { "{ServiceName}": {} }
+  }
 }

--- a/servapps/N8n/cosmos-compose.json
+++ b/servapps/N8n/cosmos-compose.json
@@ -22,9 +22,6 @@
         "cosmos-stack": "{ServiceName}",
         "cosmos-stack-main": "{ServiceName}"
       },
-      "networks": {
-        "{ServiceName}-postgres": {}
-      },
       "volumes": [
         {
           "source": "{ServiceName}-n8n_storage",
@@ -54,9 +51,6 @@
       "container_name": "{ServiceName}-postgres",
       "hostname": "{ServiceName}-postgres",
       "restart": "unless-stopped",
-      "networks": {
-        "{ServiceName}-postgres": {}
-      },
       "stop_grace_period": 5,
       "security_opt": [
         "seccomp:unconfined",
@@ -79,11 +73,6 @@
         "POSTGRES_USER=n8n",
         "POSTGRES_PASSWORD={Passwords.0}"
       ]
-    }
-  },
-
-  "networks": {
-    "{ServiceName}-postgres": {
     }
   }
 }

--- a/servapps/Nextcloud/cosmos-compose.json
+++ b/servapps/Nextcloud/cosmos-compose.json
@@ -34,9 +34,6 @@
         "cosmos-stack": "{ServiceName}",
         "cosmos-stack-main": "{ServiceName}"
       },
-      "networks": {
-        "{ServiceName}-databases": {}
-      },
       "volumes": [
         {
           "source": "{ServiceName}-config",
@@ -131,9 +128,6 @@
         "seccomp:unconfined",
         "apparmor:unconfined"
       ],
-      "networks": {
-        "{ServiceName}-databases": {}
-      },
       "command": "mariadbd --innodb-buffer-pool-size=512M --transaction-isolation=READ-COMMITTED --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --max-connections=512 --innodb-rollback-on-timeout=OFF --innodb-lock-wait-timeout=120",
       "volumes": [
         {
@@ -172,9 +166,6 @@
         "cosmos-stack": "{ServiceName}",
         "cosmos-stack-main": "{ServiceName}"
       },
-      "networks": {
-        "{ServiceName}-databases": {}
-      },
       "volumes": [
         {
           "source": "{ServiceName}-redis-data",
@@ -184,11 +175,6 @@
       ],
       "command": "redis-server --requirepass {Passwords.2} --appendonly yes --auto-aof-rewrite-percentage 100 --auto-aof-rewrite-min-size 64mb",
       "environment": []
-    }
-  },
-
-  "networks": {
-    "{ServiceName}-databases": {
     }
   }
 }

--- a/servapps/Odoo/cosmos-compose.json
+++ b/servapps/Odoo/cosmos-compose.json
@@ -92,8 +92,5 @@
         "cosmos.stack": "{ServiceName}"
       }
     }
-  },
-  "networks": {
-    "cosmos-{ServiceName}": {}
   }
 }

--- a/servapps/Opencart/cosmos-compose.json
+++ b/servapps/Opencart/cosmos-compose.json
@@ -18,9 +18,6 @@
       "depends_on": {
         "{ServiceName}-db": {}
       },
-      "networks": {
-        "{ServiceName}": {}
-      },
       "volumes": [
         {
           "source": "{ServiceName}-opencart-data",
@@ -57,9 +54,6 @@
       "container_name": "{ServiceName}-db",
       "hostname": "{ServiceName}-db",
       "restart": "unless-stopped",
-      "networks": {
-        "{ServiceName}": {}
-      },
       "volumes": [
         {
           "source": "{ServiceName}-db",
@@ -79,8 +73,5 @@
         "cosmos-stack-main": "{ServiceName}"
       }
     }
-  },
-  "networks": {
-    "{ServiceName}": {}
   }
 }

--- a/servapps/Passbolt/cosmos-compose.json
+++ b/servapps/Passbolt/cosmos-compose.json
@@ -13,9 +13,6 @@
           "image": "passbolt/passbolt:latest-ce",
           "restart": "unless-stopped",
           "container_name": "{ServiceName}",
-          "networks": {
-             "{ServiceName}-net": {}
-          },
           "environment": [
              "APP_FULL_BASE_URL=https://{Hostnames.{StaticServiceName}.{StaticServiceName}.host}",
              "DATASOURCES_DEFAULT_HOST={ServiceName}-db",
@@ -66,9 +63,6 @@
           "image": "mariadb:10.11",
           "restart": "unless-stopped",
           "container_name": "{ServiceName}-db",
-          "networks": {
-             "{ServiceName}-net": {}
-          },
           "hostname": "{ServiceName}-mariadb",
           "environment": [
              "MARIADB_PASSWORD={Passwords.0}",
@@ -91,8 +85,5 @@
              "cosmos-stack-main": "{ServiceName}"
           }
        }
-    },
-    "networks": {
-       "{ServiceName}-net": {}
     }
  }

--- a/servapps/Photoprism/cosmos-compose.json
+++ b/servapps/Photoprism/cosmos-compose.json
@@ -52,9 +52,6 @@
         "cosmos-stack": "{ServiceName}",
         "cosmos-stack-main": "{ServiceName}"
       },
-      "networks": {
-        "{ServiceName}-mariadb": {}
-      },
       "volumes": [
         {
           "source": "{ServiceName}-config",
@@ -99,9 +96,6 @@
         "seccomp:unconfined",
         "apparmor:unconfined"
       ],
-      "networks": {
-        "{ServiceName}-mariadb": {}
-      },
       "labels": {
         "cosmos-persistent-env": "MARIADB_USER, MARIADB_PASSWORD, MARIADB_ROOT_PASSWORD, MARIADB_DATABASE",
         "cosmos-stack": "{ServiceName}",
@@ -123,11 +117,6 @@
         "MARIADB_PASSWORD={Passwords.0}",
         "MARIADB_ROOT_PASSWORD={Passwords.1}"
       ]
-    }
-  },
-
-  "networks": {
-    "{ServiceName}-mariadb": {
     }
   }
 }

--- a/servapps/Pumperly/cosmos-compose.json
+++ b/servapps/Pumperly/cosmos-compose.json
@@ -28,9 +28,6 @@
         "cosmos-stack": "{ServiceName}",
         "cosmos-stack-main": "{ServiceName}"
       },
-      "networks": {
-        "{ServiceName}-network": {}
-      },
       "depends_on": [
         "{ServiceName}-db"
       ],
@@ -71,13 +68,7 @@
         "cosmos-persistent-env": "POSTGRES_DB, POSTGRES_USER, POSTGRES_PASSWORD",
         "cosmos-stack": "{ServiceName}",
         "cosmos-stack-main": "{ServiceName}"
-      },
-      "networks": {
-        "{ServiceName}-network": {}
       }
     }
-  },
-  "networks": {
-    "{ServiceName}-network": {}
   }
 }

--- a/servapps/Ryot/cosmos-compose.json
+++ b/servapps/Ryot/cosmos-compose.json
@@ -19,9 +19,6 @@
         "cosmos-stack": "{ServiceName}",
         "cosmos-stack-main": "{ServiceName}"
       },
-      "networks": {
-        "{ServiceName}-postgres": {}
-      },
       "volumes": [],
       "routes": [
         {
@@ -45,9 +42,6 @@
       "container_name": "{ServiceName}-postgres",
       "hostname": "{ServiceName}-postgres",
       "restart": "unless-stopped",
-      "networks": {
-        "{ServiceName}-postgres": {}
-      },
       "stop_grace_period": 5,
       "security_opt": [
         "seccomp:unconfined",
@@ -70,11 +64,6 @@
         "POSTGRES_USER=ryot",
         "POSTGRES_PASSWORD={Passwords.0}"
       ]
-    }
-  },
-
-  "networks": {
-    "{ServiceName}-postgres": {
     }
   }
 }

--- a/servapps/SearXNG/cosmos-compose.json
+++ b/servapps/SearXNG/cosmos-compose.json
@@ -6,9 +6,6 @@
          "container_name": "{ServiceName}",
          "image": "searxng/searxng:latest",
          "restart": "unless-stopped",
-         "networks": {
-            "{ServiceName}-net": {}
-         },
          "environment": [
          "SEARXNG_SECRET={Passwords.0}"
          ],
@@ -71,9 +68,6 @@
          "post_install": [
          "wget -O /etc/searxng/settings.yml https://raw.githubusercontent.com/searxng/searxng/refs/heads/master/utils/templates/etc/searxng/settings.yml"
          ],
-         "networks": {
-            "{ServiceName}-net": {}
-         },
          "volumes": [
             {
                "source": "{ServiceName}-data",
@@ -101,8 +95,5 @@
             "cosmos-stack-main": "{ServiceName}"
          }
       }
-   },
-   "networks": {
-      "{ServiceName}-net": {}
    }
 }

--- a/servapps/Sonarqube/cosmos-compose.json
+++ b/servapps/Sonarqube/cosmos-compose.json
@@ -26,9 +26,6 @@
         "cosmos-stack": "{ServiceName}",
         "cosmos-stack-main": "{ServiceName}"
       },
-      "networks": {
-        "{ServiceName}-postgres": {}
-      },
       "volumes": [
         {
           "source": "{ServiceName}-sonarqube-data",
@@ -67,9 +64,6 @@
       "container_name": "{ServiceName}-postgres",
       "hostname": "{ServiceName}-postgres",
       "restart": "unless-stopped",
-      "networks": {
-        "{ServiceName}-postgres": {}
-      },
       "stop_grace_period": 5,
       "security_opt": [
         "seccomp:unconfined",
@@ -93,8 +87,5 @@
         "POSTGRES_PASSWORD={Passwords.0}"
       ]
     }
-  },
-  "networks": {
-    "{ServiceName}-postgres": {}
   }
 }

--- a/servapps/Suitecrm/cosmos-compose.json
+++ b/servapps/Suitecrm/cosmos-compose.json
@@ -45,9 +45,6 @@
         "SUITECRM_ADMIN_USER={Context.SUITECRM_USERNAME}",
         "SUITECRM_ADMIN_PASSWORD={Context.SUITECRM_PASSWORD}"
       ],
-      "networks": {
-        "{ServiceName}": {}
-      },
       "labels": {
         "cosmos-persistent-env": "DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASSWORD, SITE_URL, SUITECRM_ADMIN_USER, SUITECRM_ADMIN_PASSWORD",
         "cosmos-force-network-secured": "true",
@@ -77,9 +74,6 @@
       "container_name": "{ServiceName}-db",
       "hostname": "{ServiceName}-db",
       "restart": "unless-stopped",
-      "networks": {
-        "{ServiceName}": {}
-      },
       "volumes": [
         {
           "source": "{ServiceName}-db",
@@ -99,8 +93,5 @@
         "cosmos-stack-main": "{ServiceName}"
       }
     }
-  },
-  "networks": {
-    "{ServiceName}": {}
   }
 }

--- a/servapps/Tandoor/cosmos-compose.json
+++ b/servapps/Tandoor/cosmos-compose.json
@@ -25,9 +25,6 @@
         "cosmos-stack": "{ServiceName}",
         "cosmos-stack-main": "{ServiceName}"
       },
-      "networks": {
-        "{ServiceName}-postgres": {}
-      },
       "volumes": [
         {
           "source": "{ServiceName}-staticfiles",
@@ -67,9 +64,6 @@
         "seccomp:unconfined",
         "apparmor:unconfined"
       ],
-      "networks": {
-        "{ServiceName}-postgres": {}
-      },
       "volumes": [
         {
           "source": "{ServiceName}-postgres-data",
@@ -87,11 +81,6 @@
         "POSTGRES_USER=tandoor",
         "POSTGRES_PASSWORD={Passwords.0}"
       ]
-    }
-  },
-
-  "networks": {
-    "{ServiceName}-postgres": {
     }
   }
 }

--- a/servapps/Wordpress/cosmos-compose.json
+++ b/servapps/Wordpress/cosmos-compose.json
@@ -30,9 +30,6 @@
         "cosmos-stack": "{ServiceName}",
         "cosmos-stack-main": "{ServiceName}"
       },
-      "networks": {
-        "{ServiceName}-mysql": {}
-      },
       "routes": [
         {
           "name": "{ServiceName}",
@@ -60,9 +57,6 @@
         "seccomp:unconfined",
         "apparmor:unconfined"
       ],
-      "networks": {
-        "{ServiceName}-mysql": {}
-      },
       "volumes": [
         {
           "source": "{ServiceName}-mysql-data",
@@ -81,11 +75,6 @@
         "MYSQL_PASSWORD={Passwords.0}",
         "MYSQL_ROOT_PASSWORD={Passwords.1}"
       ]
-    }
-  },
-
-  "networks": {
-    "{ServiceName}-mysql": {
     }
   }
 }

--- a/servapps/Zipline/cosmos-compose.json
+++ b/servapps/Zipline/cosmos-compose.json
@@ -123,9 +123,6 @@
         "depends_on": {
           "{ServiceName}-postgres" : {}
         },
-        "networks": {
-          "{ServiceName}-data": {}
-        },
         "volumes": [
           {if Context.useBinds}
           {if not Context.s3storage}
@@ -201,9 +198,6 @@
           "timeout": 5,
           "retries": 5
         },
-        "networks": {
-          "{ServiceName}-data": {}
-        },
         "labels": {
           "cosmos-persistent-env": "POSTGRES_DB, POSTGRES_USER, POSTGRES_PASSWORD",
           "cosmos-force-network-secured": "true",
@@ -224,11 +218,6 @@
           "POSTGRES_USER=zipline",
           "POSTGRES_PASSWORD={Passwords.0}"
         ]
-      }
-    },
-  
-    "networks": {
-      "{ServiceName}-data": {
       }
     }
   }

--- a/servapps/phpbb/cosmos-compose.json
+++ b/servapps/phpbb/cosmos-compose.json
@@ -13,9 +13,6 @@
     "{ServiceName}-mariadb": {
       "image": "mariadb:11.4",
       "container_name": "{ServiceName}-mariadb",
-      "networks": {
-        "{ServiceName}-net": {}
-      },
       "hostname": "{ServiceName}-mariadb",
       "environment": [
         "MARIADB_PASSWORD={Passwords.0}",
@@ -41,9 +38,6 @@
     "{ServiceName}": {
       "image": "selim13/phpbb:3.3",
       "container_name": "{ServiceName}",
-      "networks": {
-        "{ServiceName}-net": {}
-      },
       "environment": [
         "PHPBB_INSTALL=true",
         "PHPBB_DB_DRIVER=mysqli",
@@ -103,8 +97,5 @@
         "{ServiceName}-mariadb": {}
       }
     }
-  },
-  "networks": {
-    "{ServiceName}-net": {}
   }
 }

--- a/servapps/redmine/cosmos-compose.json
+++ b/servapps/redmine/cosmos-compose.json
@@ -59,9 +59,6 @@
           "REDMINE_FIRST_NAME={Context.REDMINE_FIRST_NAME}",
           "REDMINE_LAST_NAME={Context.REDMINE_LAST_NAME}"
         ],
-        "networks": {
-            "{ServiceName}": {}
-          },
           "labels": {
             "cosmos-persistent-env": "REDMINE_DB_PASSWORD, REDMINE_DB_MYSQL, REDMINE_DB_USERNAME, REDMINE_DB_DATABASE, REDMINE_DB_PORT, SECRET_KEY_BASE",
             "cosmos-force-network-secured": "true",
@@ -90,9 +87,6 @@
         "container_name": "{ServiceName}-db",
         "hostname": "{ServiceName}-db",
         "restart": "unless-stopped",
-        "networks": {
-            "{ServiceName}": {}
-          },
         "volumes": [
           {
             "source": "{ServiceName}-db",
@@ -112,8 +106,5 @@
           "cosmos-stack-main": "{ServiceName}"
         }
       }
-    },
-    "networks": {
-        "{ServiceName}": {}
-      }
+    }
   }


### PR DESCRIPTION
## What

Same change as **#302** (merged to `unstable`), opened against `master` so the cleanup lands on the default/release branch too.

Removes the redundant per-service custom `networks:` blocks (and their matching top-level `networks:` declarations) from **36 servapp templates**, including the legacy `network_mode` pattern in **Odoo**.

Cosmos already puts every container of a stack on its own shared network, so these explicit networks are unnecessary:

- All stack containers resolve each other by `container_name` over the stack's default network — no custom network needed for inter-service DNS (e.g. `{ServiceName}-postgres:5432`).
- Isolation is already enforced by `cosmos-force-network-secured: "true"` on each container.
- Each custom network forces Cosmos to **create and tear down an extra Docker network per app install/update**, and leaves dangling `{ServiceName}-*` networks behind on uninstall.

This follows the exact same change merged for **Piped (#300)**: *"Remove the custom {ServiceName}-net network: Cosmos puts all stack containers on its default network, so explicit networks are redundant."*

## Changed apps (36)

Cachet, CashPilot, Discourse, Drupal, Firefly-III, Flarum, GenieACS, Ghost, Immich, Jellystat, Joplin, Keycloak, Kitchenowl, LynxPrompt, Manyfold, Mastodon, MediaWiki, Miniflux, Monica, Moodle, N8n, Nextcloud, **Odoo**, Opencart, Passbolt, Photoprism, Pumperly, Ryot, SearXNG, Sonarqube, Suitecrm, Tandoor, Wordpress, Zipline, phpbb, redmine.

Each file: removed per-service `"networks": { ... }` attach blocks + the top-level `"networks": { ... }` declaration.

**Odoo additionally:** removed the legacy `network_mode: cosmos-{ServiceName}` from both services and a stray orphan `{/if}` (the only such error in the repo).

## Redundancy verification

From Cosmos source (`client/src/pages/servapps/containers/docker-compose.jsx`): at install time, for **every service without an explicit `network_mode`**, the frontend injects `network_mode = 'cosmos-{ServiceName}-default'` and creates **one** top-level `cosmos-{ServiceName}-default` network. All stack services therefore share one network and resolve each other by container name.

Audited every removed network block against the rendered templates:

| Check | Result |
|---|---|
| Networks removed that attached **all** stack services (no partial segmentation) | **35 / 35** |
| Networks removed that attached only a **subset** of services (would break) | **0** |
| Templates with lingering `network_mode` / `networks` after removal | **0** |
| Inter-service hostname refs all point at sibling services on the default net | **all pass** |
| `Lemmy` (intentional `internal: true` network) | **kept untouched** |

## Diff hygiene

Diffs are **pure deletions** of the network blocks — 36 files, **+7 / −345**. The only 7 added lines are the `}` close-brace reflows that JSON requires when a removed block was the last key of its parent (`},` → `}`). **Zero added empty or whitespace-only lines.** CRLF line endings and EOF-newline state preserved where the originals used them.

## Validation

- Repo whiskers validator on this branch: **all apps checked, exit 0, 0 errors**.
- CI `validate` on #302 (identical change on `unstable`): green.