### PR TITLE
fix(libredb-studio): update image to 0.16.0

### DIFF
--- a/servapps/LibreDB-Studio/cosmos-compose.json
+++ b/servapps/LibreDB-Studio/cosmos-compose.json
@@ -3,7 +3,7 @@
     "minVersion": "0.9.0",
     "services": {
         "{ServiceName}": {
-            "image": "ghcr.io/libredb/libredb-studio:0.9.59",
+            "image": "ghcr.io/libredb/libredb-studio:0.15.0",
             "container_name": "{ServiceName}",
             "restart": "unless-stopped",
             "environment": [


### PR DESCRIPTION
Updates the LibreDB Studio servapp to the current release.

`servapps/LibreDB-Studio/cosmos-compose.json`: image `ghcr.io/libredb/libredb-studio:0.9.59` to `0.15.0`

0.9.59 predates the project's security work. Everything below was fixed in the releases between the two tags: the SSH tunnel did not verify the host key, so traffic including passwords was open to a machine in the middle; an image proxy accepted any URL without authentication; two cross-site scripting sinks; a maintenance route that checked the wrong thing and let a direct request vacuum the whole SQLite file; and five high severity Next.js middleware bypass advisories that came with the framework bump.

The 0.15.0 tag is published on ghcr.io for linux/amd64 and linux/arm64.

Nothing else changes. The environment variables, the `/app/data` volume, the route on port 3000 and the labels stay as they are. Existing installs are not touched by this, since the template only affects new installs and a user's own update, and there is no data migration or manual step between these versions.

`node .github/scripts/validate-servapps.js LibreDB-Studio` passes.

I maintain LibreDB Studio.
